### PR TITLE
Clip ncs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read a project description [here](https://secasc.ncsu.edu/2023/08/28/modeling-hy
 - To coerce the data into a netCDF format, run the following command to submit an `sbatch` script. Change the script locations to match your repo location, and change the `--output_dir` argument to save the netCDF files to a different location and avoid overwriting previous outputs. The script should only take ~5 minutes to run once compute resources are allocated.
 
 ```
-python run_build_nc.py --data_dir /beegfs/CMIP6/jdpaul3/hydroviz_data/stats --output_dir /beegfs/CMIP6/jdpaul3/hydroviz_data/nc --conda_init_script /beegfs/CMIP6/jdpaul3/hydroviz/conda_init.sh --conda_env_name snap-geo --build_nc_script /beegfs/CMIP6/jdpaul3/hydroviz/build_nc.py
+python run_build_nc.py --data_dir /beegfs/CMIP6/jdpaul3/hydroviz_data/stats --gis_dir /beegfs/CMIP6/jdpaul3/hydroviz_data/gis --output_dir /beegfs/CMIP6/jdpaul3/hydroviz_data/nc --conda_init_script /beegfs/CMIP6/jdpaul3/hydroviz/conda_init.sh --conda_env_name snap-geo --build_nc_script /beegfs/CMIP6/jdpaul3/hydroviz/build_nc.py
 ```
 
 - Use the `qc.ipynb` notebook to compare values in the netCDFs to source values.

--- a/build_nc.py
+++ b/build_nc.py
@@ -3,6 +3,7 @@ import sys
 import os
 from pathlib import Path
 import pandas as pd
+import geopandas as gpd
 from datetime import datetime
 from functions import *
 
@@ -11,18 +12,20 @@ def arguments(argv):
     """Parse some args"""
     parser = argparse.ArgumentParser()
     parser.add_argument("--data_dir", type=str, help="directory where hydrologic stats CSVs are located", required=True)
+    parser.add_argument("--gis_dir", type=str, help="directory where GIS files are located", required=True)
     parser.add_argument("--output_dir", type=str, help="directory where hydrologic stats netCDFs will be saved", required=True)
    
     args = parser.parse_args()
     data_dir = args.data_dir
+    gis_dir = args.gis_dir
     output_dir = args.output_dir
 
-    return data_dir, output_dir
+    return data_dir, gis_dir, output_dir
 
 
 if __name__ == "__main__":
 
-    data_dir, output_dir = arguments(sys.argv)
+    data_dir, gis_dir, output_dir = arguments(sys.argv)
 
     print(f"Reading hydro stats CSVs from {data_dir}...\n")
 
@@ -36,6 +39,16 @@ if __name__ == "__main__":
     # filter files
     seg_files = filter_files(seg_files, "seg")
     hru_files = filter_files(hru_files, "hru")
+
+    print(f"Reading GIS files from {gis_dir}...\n")
+
+    # get seg/hru shapefiles to extract IDs
+    seg_shp_path = os.path.join(gis_dir, "Segments_subset.shp")
+    seg_shp = gpd.read_file(seg_shp_path)
+    hru_shp_path = os.path.join(gis_dir, "HRU_subset.shp")
+    hru_shp = gpd.read_file(hru_shp_path)
+    # get crosswalk to fix HRU IDs
+    hru_xwalk = pd.read_csv(os.path.join(gis_dir, "nhm_hru_id_crosswalk.csv"), dtype={'hru_id':str, 'hru_id_nat':str})
 
     print(f"Parsing geometry IDs and model / scenario / era coordinates...\n")
 
@@ -53,7 +66,9 @@ if __name__ == "__main__":
     print("Creating empty netCDF dataset to hold stream segment statistics...\n")
     seg_ds = create_empty_dataset(geom_coords_dict["seg"], seg_ids)
     print(f"Populating dataset from {len(seg_files)} stream segment statistic CSVs...\n")
-    populate_dataset(seg_ds, seg_files)
+    seg_ds = populate_dataset(seg_ds, seg_files)
+    print(f"Clipping dataset to the extent of {seg_shp_path} ...\n")
+    seg_ds = clip_dataset(seg_ds, seg_shp, "seg")
     seg_outfile = os.path.join(output_dir, "seg.nc")
     print(f"Writing populated netCDF to {seg_outfile}...\n")
     seg_ds.to_netcdf(seg_outfile)
@@ -62,7 +77,10 @@ if __name__ == "__main__":
     print("Creating empty netCDF dataset to hold watershed statistics...\n")
     hru_ds = create_empty_dataset(geom_coords_dict["hru"], hru_ids)
     print(f"Populating dataset from {len(hru_files)} watershed statistic CSVs...\n")
-    populate_dataset(hru_ds, hru_files)
+    hru_ds = populate_dataset(hru_ds, hru_files)
+    hru_ds = crosswalk_hrus(hru_ds, hru_xwalk)
+    print(f"Clipping dataset to the extent of {hru_shp_path} ...\n")
+    hru_ds = clip_dataset(hru_ds, "hru")
     hru_outfile = os.path.join(output_dir, "hru.nc")
     print(f"Writing populated netCDF to {hru_outfile}...\n")
     hru_ds.to_netcdf(hru_outfile)

--- a/build_nc.py
+++ b/build_nc.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     hru_ds = populate_dataset(hru_ds, hru_files)
     hru_ds = crosswalk_hrus(hru_ds, hru_xwalk)
     print(f"Clipping dataset to the extent of {hru_shp_path} ...\n")
-    hru_ds = clip_dataset(hru_ds, "hru")
+    hru_ds = clip_dataset(hru_ds, hru_shp, "hru")
     hru_outfile = os.path.join(output_dir, "hru.nc")
     print(f"Writing populated netCDF to {hru_outfile}...\n")
     hru_ds.to_netcdf(hru_outfile)

--- a/functions.py
+++ b/functions.py
@@ -133,9 +133,23 @@ def populate_dataset(ds, files):
             # drop column after use (improves performance)
             df.drop(columns=[stat], inplace=True)
 
-    return 
+    return ds
 
 
-#TODO: add QC function that picks random CSVs and checks that the data is in the right place in the netCDF
+def crosswalk_hrus(ds, df):
+    xwalk_dict = {k: v for k, v in zip(df['hru_id'], df['hru_id_nat'])}
+    new_ids = [xwalk_dict.get(k) for k in ds['geom_id'].values.tolist()]
+    ds['geom_id'] = new_ids
+    return ds
+
+
+def clip_dataset(ds, shp, type):
+# clip the dataset to the actual data extent using geometry IDs
+
+    if type == "seg":
+        ds = ds.sel(geom_id = ds.geom_id.isin(shp.seg_id_nat.astype(str).tolist()))
+        return ds
+    elif type == "hru":
+        ds = ds.sel(geom_id = ds.geom_id.isin(shp.hru_id_nat.astype(str).tolist()))
 
 #TODO: add function to write netCDF metadata from stat descriptions in luts.py and general dataset info

--- a/functions.py
+++ b/functions.py
@@ -151,5 +151,6 @@ def clip_dataset(ds, shp, type):
         return ds
     elif type == "hru":
         ds = ds.sel(geom_id = ds.geom_id.isin(shp.hru_id_nat.astype(str).tolist()))
+        return ds
 
 #TODO: add function to write netCDF metadata from stat descriptions in luts.py and general dataset info

--- a/run_build_nc.py
+++ b/run_build_nc.py
@@ -8,6 +8,7 @@ def arguments(argv):
     """Parse some args"""
     parser = argparse.ArgumentParser()
     parser.add_argument("--data_dir", type=str, help="directory where hydrologic stats CSVs are located", required=True)
+    parser.add_argument("--gis_dir", type=str, help="directory where GIS files are located", required=True)
     parser.add_argument("--output_dir", type=str, help="directory where hydrologic stats netCDFs will be saved", required=True)
     parser.add_argument("--conda_init_script", type=str, help="location of conda initialization script", required=True)
     parser.add_argument("--conda_env_name", type=str, help="conda environment to use", required=True)
@@ -15,12 +16,13 @@ def arguments(argv):
     
     args = parser.parse_args()
     data_dir = args.data_dir
+    gis_dir = args.gis_dir
     output_dir = args.output_dir
     conda_init_script = args.conda_init_script
     conda_env_name = args.conda_env_name
     build_nc_script = args.build_nc_script
 
-    return data_dir, output_dir, conda_init_script, conda_env_name, build_nc_script
+    return data_dir, gis_dir, output_dir, conda_init_script, conda_env_name, build_nc_script
 
 
 def write_sbatch_head(sbatch_out_fp, conda_init_script, conda_env_name):
@@ -56,6 +58,7 @@ def write_sbatch(
     sbatch_head,
     build_nc_script,
     data_dir,
+    gis_dir,
     output_dir,
 ):
     """Write an sbatch script for building the netCDFs
@@ -72,6 +75,7 @@ def write_sbatch(
     pycommands += (
         f"python {build_nc_script} "
         f"--data_dir {data_dir} "
+        f"--gis_dir {gis_dir} "
         f"--output_dir {output_dir} "
     )
     pycommands += "\n\n"
@@ -101,7 +105,7 @@ def submit_sbatch(sbatch_fp):
 
 if __name__ == "__main__":
 
-    data_dir, output_dir, conda_init_script, conda_env_name, build_nc_script = arguments(sys.argv)
+    data_dir, gis_dir, output_dir, conda_init_script, conda_env_name, build_nc_script = arguments(sys.argv)
 
     # create the output directory if it doesn't exist
     Path(output_dir).mkdir(exist_ok=True, parents=True)
@@ -112,5 +116,5 @@ if __name__ == "__main__":
 
     # write sbatch head + commands, then submit job
     sbatch_head = write_sbatch_head(sbatch_out_fp, conda_init_script, conda_env_name)
-    write_sbatch(sbatch_fp, sbatch_out_fp, sbatch_head, build_nc_script, data_dir, output_dir)
+    write_sbatch(sbatch_fp, sbatch_out_fp, sbatch_head, build_nc_script, data_dir, gis_dir, output_dir)
     submit_sbatch(sbatch_fp)


### PR DESCRIPTION
This PR clips the output NC files to the spatial extent of the modeled dataset. This is done by adding functions to read the stream segment and watershed IDs from the shapefile subsets, and only include the modeled data matching these IDs.

The intention is to remove unmodeled segments/watersheds from the NC files, which before now simply contained null values and took up extra disk space.