### PR TITLE
Crosswalk shps to add GNIS names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ python run_build_nc.py --data_dir /beegfs/CMIP6/jdpaul3/hydroviz_data/stats --gi
 ```
 
 - Use the `qc.ipynb` notebook to compare values in the netCDFs to source values.
+
+- Run the `xwalk.ipynb` notebook to crosswalk stream segment IDs and watershed IDs from the project geospatial data (`Segments_subset.shp` and `HRU_subset.shp`) to the GNIS name attributes in the NHM geospatial fabric. This notebook exports new shapefiles with the added GNIS common names for hosting in GeoServer ([gs.earthmaps.io](http://gs.earthmaps.io/)).

--- a/xwalk.ipynb
+++ b/xwalk.ipynb
@@ -617,7 +617,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Save to a local directory, then manually zip and move to the `shp` directory in the repo. This is the final geometry that will be uploaded onto GeoServer for query via the API!"
+    "Save to a local directory, then manually zip. This is the final geometry that will be uploaded onto GeoServer for query via the API!"
    ]
   },
   {

--- a/xwalk.ipynb
+++ b/xwalk.ipynb
@@ -1,0 +1,658 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Download Geospatial Fabric from ScienceBase and Crosswalk\n",
+    "\n",
+    "This notebook downloads the NHM geospatial fabric from ScienceBase using their API, which means direct download from AWS S3 buckets instead of point and click downloads from their web interface. This notebook follows usage instructions in their github [documentation](https://github.com/DOI-USGS/sciencebasepy/blob/master/README.md).\n",
+    "\n",
+    "Only use this notebook if you need your own copy of the dataset. Otherwise just use the data located in the directory below.\n",
+    "\n",
+    "The NHM geospatial fabric files are used to crosswalk stream segment IDs and watershed IDs from the project geospatial data (`Segments_subset.shp` and `HRU_subset.shp`) to the attributes in the NHM geospatial fabric, specifically the GNIS name attributes present in the POI (point of interest) layer. This will associate common names to the modeled stream segments and watersheds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sciencebasepy\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "import fiona\n",
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "\n",
+    "#dir = Path(\"/import/beegfs/CMIP6/jdpaul3/hydroviz_data\")\n",
+    "dir = Path(\"/Users/joshpaul/secasc_hydroviz/hydroviz_data\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Establish a session and get public items.  No need to log in!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb = sciencebasepy.SbSession()\n",
+    "\n",
+    "# This is the NHM geospatial fabric item from here: https://www.sciencebase.gov/catalog/item/5362b683e4b0c409c6289bf6\n",
+    "item = '5362b683e4b0c409c6289bf6'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the item JSON and check the files within."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GeospatialFabricFeatures_01.zip\n",
+      "GeospatialFabricFeatures_02.zip\n",
+      "GeospatialFabricFeatures_03.zip\n",
+      "GeospatialFabricFeatures_04.zip\n",
+      "GeospatialFabricFeatures_05.zip\n",
+      "GeospatialFabricFeatures_06.zip\n",
+      "GeospatialFabricFeatures_07.zip\n",
+      "GeospatialFabricFeatures_08.zip\n",
+      "GeospatialFabricFeatures_09.zip\n",
+      "GeospatialFabricFeatures_10L.zip\n",
+      "GeospatialFabricFeatures_10U.zip\n",
+      "GeospatialFabricFeatures_11.zip\n",
+      "GeospatialFabricFeatures_12.zip\n",
+      "GeospatialFabricFeatures_13.zip\n",
+      "GeospatialFabricFeatures_14.zip\n",
+      "GeospatialFabricFeatures_15.zip\n",
+      "GeospatialFabricFeatures_16.zip\n",
+      "GeospatialFabricFeatures_17.zip\n",
+      "GeospatialFabricFeatures_18.zip\n",
+      "GeospatialFabricFeatures_20.zip\n",
+      "GeospatialFabricFeatures_21.zip\n",
+      "GeospatialFabric_National.gdb.zip\n"
+     ]
+    }
+   ],
+   "source": [
+    "item_json = sb.get_item(item)\n",
+    "for file in item_json['files']:\n",
+    "    print(file['name'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We want the whole CONUS, so might as well download `GeospatialFabric_National.gdb.zip`. Let's use the `sciencebasepy.download_file()` function to download that file by URL, and then unzip it to our project `gis` subdirectory. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "downloading https://www.sciencebase.gov/catalog/file/get/5362b683e4b0c409c6289bf6?f=__disk__41%2F2e%2Ff6%2F412ef640321f29c011095d1209103bfb3688d021 to /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb.zip\n"
+     ]
+    }
+   ],
+   "source": [
+    "for file in item_json['files']:\n",
+    "    if file['name'] == 'GeospatialFabric_National.gdb.zip':\n",
+    "        sb.download_file(file['url'], os.path.join(dir, \"gis\", file['name']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Archive:  /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb.zip\n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000001.freelist  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000001.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000001.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000001.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000001.TablesByName.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000002.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000002.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000003.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000003.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000003.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000004.CatItemsByPhysicalName.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000004.CatItemsByType.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000004.FDO_UUID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000004.freelist  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000004.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000004.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000004.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000004.spx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000005.CatItemTypesByName.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000005.CatItemTypesByParentTypeID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000005.CatItemTypesByUUID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000005.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000005.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000005.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000006.CatRelsByDestinationID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000006.CatRelsByOriginID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000006.CatRelsByType.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000006.FDO_UUID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000006.freelist  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000006.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000006.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000006.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000007.CatRelTypesByBackwardLabel.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000007.CatRelTypesByDestItemTypeID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000007.CatRelTypesByForwardLabel.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000007.CatRelTypesByName.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000007.CatRelTypesByOriginItemTypeID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000007.CatRelTypesByUUID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000007.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000007.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000007.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000000b.freelist  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000000b.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000000b.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000000b.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000000b.spx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000000c.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000000c.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000000c.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000000c.spx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000011.FDO_COMID.atx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000011.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000011.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000011.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000011.spx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000013.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000013.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000013.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000013.spx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000001a.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000001a.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000001a.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000002f.freelist  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000002f.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000002f.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000002f.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a0000002f.spx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000032.freelist  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000032.gdbindexes  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000032.gdbtable  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000032.gdbtablx  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/a00000032.spx  \n",
+      " extracting: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/gdb  \n",
+      " extracting: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/nsegmentHeadwaters.RC_RVIGER_230.4872.5688.sr.lock  \n",
+      " extracting: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/POIs.RC_RVIGER_230.4872.5688.sr.lock  \n",
+      "  inflating: /Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/GeospatialFabric_National.gdb/timestamps  \n"
+     ]
+    }
+   ],
+   "source": [
+    "zippath = list(dir.glob(f'**/GeospatialFabric_National.gdb.zip'))[0]\n",
+    "output_dir = zippath.parent\n",
+    "zippath_str = str(zippath)\n",
+    "!unzip {zippath_str} -d {output_dir}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the geodatabase path, and check out the layers. We want to read in the national identifier layers and the POI layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['POIs',\n",
+       " 'one',\n",
+       " 'nhdflowline_en',\n",
+       " 'nhdflowline',\n",
+       " 'regionOutletDA',\n",
+       " 'nhruNationalIdentifier',\n",
+       " 'nsegmentNationalIdentifier']"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gdb_path = list(output_dir.glob('**/*.gdb'))[0]\n",
+    "fiona.listlayers(gdb_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/joshpaul/miniconda3/envs/snap-geo/lib/python3.11/site-packages/geopandas/io/file.py:399: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_datetime without passing `errors` and catch exceptions explicitly instead\n",
+      "  as_dt = pd.to_datetime(df[k], errors=\"ignore\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "poi_gdf = gpd.read_file(gdb_path, layer='POIs', encoding='utf-8')\n",
+    "gf_hru_gdf = gpd.read_file(gdb_path, layer='nhruNationalIdentifier', encoding='utf-8')\n",
+    "gf_seg_gdf = gpd.read_file(gdb_path, layer='nsegmentNationalIdentifier', encoding='utf-8')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Join the POI names using the POI ID."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/dz/1ccfqg_n5mg3fsrt8rwm7fd80000gn/T/ipykernel_5536/672524861.py:2: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  gf_seg['POI_ID'] = gf_seg['POI_ID'].astype(int)\n"
+     ]
+    }
+   ],
+   "source": [
+    "gf_seg = gf_seg_gdf[['seg_id_nat', 'POI_ID']]\n",
+    "gf_seg['POI_ID'] = gf_seg['POI_ID'].astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/dz/1ccfqg_n5mg3fsrt8rwm7fd80000gn/T/ipykernel_5536/2049412994.py:2: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  gf_hru['POI_ID'] = gf_hru['POI_ID'].astype(int)\n"
+     ]
+    }
+   ],
+   "source": [
+    "gf_hru = gf_hru_gdf[['hru_id_nat', 'POI_ID']]\n",
+    "gf_hru['POI_ID'] = gf_hru['POI_ID'].astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/dz/1ccfqg_n5mg3fsrt8rwm7fd80000gn/T/ipykernel_5536/2045475214.py:2: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  poi['COMID'] = poi['COMID'].astype(int)\n"
+     ]
+    }
+   ],
+   "source": [
+    "poi = poi_gdf[['COMID', 'GNIS_NAME']]\n",
+    "poi['COMID'] = poi['COMID'].astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gf_seg = gf_seg.join(poi.set_index('COMID'), on='POI_ID')\n",
+    "gf_hru = gf_hru.join(poi.set_index('COMID'), on='POI_ID')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now read in the project segment and watershed shapefiles, and join the names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PosixPath('/Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/HRU_subset.shp'),\n",
+       " PosixPath('/Users/joshpaul/secasc_hydroviz/hydroviz_data/gis/Segments_subset.shp')]"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "project_shps = list(dir.glob(f'**/*subset.shp'))\n",
+    "project_shps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hru_gdf = gpd.read_file(project_shps[0])\n",
+    "seg_gdf = gpd.read_file(project_shps[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hru_gdf = hru_gdf.join(gf_hru.set_index('hru_id_nat'), on='hru_id_nat')\n",
+    "seg_gdf = seg_gdf.join(gf_seg.set_index('seg_id_nat'), on='seg_id_nat')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>region</th>\n",
+       "      <th>hru_id_nat</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>POI_ID</th>\n",
+       "      <th>GNIS_NAME</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>17</td>\n",
+       "      <td>93013</td>\n",
+       "      <td>POLYGON ((-1661303.115 2221244.978, -1661298.6...</td>\n",
+       "      <td>23336004</td>\n",
+       "      <td>South Fork Owyhee River</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>17</td>\n",
+       "      <td>93014</td>\n",
+       "      <td>MULTIPOLYGON (((-1532954.896 2215904.774, -153...</td>\n",
+       "      <td>23198872</td>\n",
+       "      <td>Dry Creek</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>17</td>\n",
+       "      <td>93015</td>\n",
+       "      <td>POLYGON ((-1532985.250 2215875.115, -1532984.8...</td>\n",
+       "      <td>23198872</td>\n",
+       "      <td>Dry Creek</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>17</td>\n",
+       "      <td>93016</td>\n",
+       "      <td>POLYGON ((-1546064.860 2230034.835, -1546065.0...</td>\n",
+       "      <td>23196836</td>\n",
+       "      <td>Jakes Creek</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>17</td>\n",
+       "      <td>93017</td>\n",
+       "      <td>POLYGON ((-1546065.114 2230081.069, -1546065.0...</td>\n",
+       "      <td>23196800</td>\n",
+       "      <td>Jakes Creek</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  region  hru_id_nat                                           geometry  \\\n",
+       "0     17       93013  POLYGON ((-1661303.115 2221244.978, -1661298.6...   \n",
+       "1     17       93014  MULTIPOLYGON (((-1532954.896 2215904.774, -153...   \n",
+       "2     17       93015  POLYGON ((-1532985.250 2215875.115, -1532984.8...   \n",
+       "3     17       93016  POLYGON ((-1546064.860 2230034.835, -1546065.0...   \n",
+       "4     17       93017  POLYGON ((-1546065.114 2230081.069, -1546065.0...   \n",
+       "\n",
+       "     POI_ID                GNIS_NAME  \n",
+       "0  23336004  South Fork Owyhee River  \n",
+       "1  23198872                Dry Creek  \n",
+       "2  23198872                Dry Creek  \n",
+       "3  23196836              Jakes Creek  \n",
+       "4  23196800              Jakes Creek  "
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hru_gdf.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>region</th>\n",
+       "      <th>seg_id_nat</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>POI_ID</th>\n",
+       "      <th>GNIS_NAME</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>01</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LINESTRING (2101948.624 2876678.641, 2101941.3...</td>\n",
+       "      <td>955</td>\n",
+       "      <td>West Branch Mattawamkeag River</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>01</td>\n",
+       "      <td>2</td>\n",
+       "      <td>LINESTRING (2167789.031 2829021.852, 2167729.9...</td>\n",
+       "      <td>1691</td>\n",
+       "      <td>Baskahegan Stream</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>01</td>\n",
+       "      <td>3</td>\n",
+       "      <td>LINESTRING (2131936.492 2865675.020, 2131955.7...</td>\n",
+       "      <td>1933</td>\n",
+       "      <td>Mattawamkeag River</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>01</td>\n",
+       "      <td>4</td>\n",
+       "      <td>LINESTRING (2151719.943 2849594.051, 2151812.0...</td>\n",
+       "      <td>1945</td>\n",
+       "      <td>Mattawamkeag River</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>01</td>\n",
+       "      <td>5</td>\n",
+       "      <td>LINESTRING (2155981.103 2842240.715, 2155894.2...</td>\n",
+       "      <td>1947</td>\n",
+       "      <td>Baskahegan Stream</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  region  seg_id_nat                                           geometry  \\\n",
+       "0     01           1  LINESTRING (2101948.624 2876678.641, 2101941.3...   \n",
+       "1     01           2  LINESTRING (2167789.031 2829021.852, 2167729.9...   \n",
+       "2     01           3  LINESTRING (2131936.492 2865675.020, 2131955.7...   \n",
+       "3     01           4  LINESTRING (2151719.943 2849594.051, 2151812.0...   \n",
+       "4     01           5  LINESTRING (2155981.103 2842240.715, 2155894.2...   \n",
+       "\n",
+       "   POI_ID                       GNIS_NAME  \n",
+       "0     955  West Branch Mattawamkeag River  \n",
+       "1    1691               Baskahegan Stream  \n",
+       "2    1933              Mattawamkeag River  \n",
+       "3    1945              Mattawamkeag River  \n",
+       "4    1947               Baskahegan Stream  "
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "seg_gdf.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save to a local directory, then manually zip and move to the `shp` directory in the repo. This is the final geometry that will be uploaded onto GeoServer for query via the API!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmp_dir = Path(\"/Users/joshpaul/secasc_hydroviz/other_gis/shp_for_geoserver\")\n",
+    "repo_dir = Path(\"/Users/joshpaul/secasc_hydroviz/hydroviz\")\n",
+    "\n",
+    "seg_gdf.to_file(os.path.join(tmp_dir, 'seg.shp'))\n",
+    "hru_gdf.to_file(os.path.join(tmp_dir, 'hru.shp'))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "snap-geo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/xwalk.ipynb
+++ b/xwalk.ipynb
@@ -26,8 +26,7 @@
     "import geopandas as gpd\n",
     "import pandas as pd\n",
     "\n",
-    "#dir = Path(\"/import/beegfs/CMIP6/jdpaul3/hydroviz_data\")\n",
-    "dir = Path(\"/Users/joshpaul/secasc_hydroviz/hydroviz_data\")"
+    "dir = Path(\"/import/beegfs/CMIP6/jdpaul3/hydroviz_data\")"
    ]
   },
   {
@@ -617,7 +616,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Save to a local directory, then manually zip. This is the final geometry that will be uploaded onto GeoServer for query via the API!"
+    "Save to a scratch directory, then manually zip the files and move somewhere safe. This is the final geometry that will be uploaded onto GeoServer for query via the API."
    ]
   },
   {
@@ -626,8 +625,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tmp_dir = Path(\"/Users/joshpaul/secasc_hydroviz/other_gis/shp_for_geoserver\")\n",
-    "repo_dir = Path(\"/Users/joshpaul/secasc_hydroviz/hydroviz\")\n",
+    "tmp_dir = Path(\"/import/beegfs/CMIP6/jdpaul3/scratch\")\n",
     "\n",
     "seg_gdf.to_file(os.path.join(tmp_dir, 'seg.shp'))\n",
     "hru_gdf.to_file(os.path.join(tmp_dir, 'hru.shp'))"


### PR DESCRIPTION
This PR adds a notebook that downloads the NHM geospatial fabric, crosswalks the project geometry subset to this fabric, and uses the POI layer to add GNIS names to the streams and watersheds in the project geometry subset. New shapefiles containing the additional GNIS name attributes are exported for upload to GeoServer. 

This notebook is independent of the rest of the codebase and doesn't effect the existing data pre-processing pipeline, and so does not require a review at this point. 