### PR TITLE
Modify front end code to conform to new backend stats endpoint structure

### DIFF
--- a/webapp/components/Report.vue
+++ b/webapp/components/Report.vue
@@ -6,8 +6,8 @@ const streamSegmentStore = useStreamSegmentStore()
 let { streamStats, segmentName, isLoading } = storeToRefs(streamSegmentStore)
 
 const lcInput = defineModel('lc', { default: 'dynamic' })
-const modelInput = defineModel('model', { default: 'ACCESS1-0' })
-const scenarioInput = defineModel('scenario', { default: 'rcp85' })
+const modelInput = defineModel('model', { default: 'CCSM4' })
+const scenarioInput = defineModel('scenario', { default: 'rcp60' })
 </script>
 
 <template>
@@ -77,9 +77,9 @@ const scenarioInput = defineModel('scenario', { default: 'rcp85' })
               <td class="p-5">
                 {{
                   Number(
-                    streamStats[lcInput][modelInput]['historical']['1976_2005'][
-                      stat
-                    ]
+                    streamStats.data[lcInput][modelInput]['historical'][
+                      '1976-2005'
+                    ][stat]
                   ).toFixed(2)
                 }}
                 <span style="color: #888">{{ statVars[stat].units }}</span>
@@ -87,7 +87,9 @@ const scenarioInput = defineModel('scenario', { default: 'rcp85' })
               <td v-for="era in Object.keys(eras)" class="p-5">
                 {{
                   Number(
-                    streamStats[lcInput][modelInput][scenarioInput][era][stat]
+                    streamStats.data[lcInput][modelInput][scenarioInput][era][
+                      stat
+                    ]
                   ).toFixed(2)
                 }}
                 <span style="color: #888">{{ statVars[stat].units }}</span>

--- a/webapp/stores/streamSegment.ts
+++ b/webapp/stores/streamSegment.ts
@@ -9,14 +9,14 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
   const { $config } = useNuxtApp()
 
   const fetchStreamStats = async (): Promise<void> => {
-    let requestUrl = `${$config.public.snapApiUrl}/conus_hydrology/${segmentId.value}`
+    let requestUrl = `${$config.public.snapApiUrl}/conus_hydrology/stats/${segmentId.value}`
     streamStats.value = null
 
     // Needs error checking, etc.
     isLoading.value = true
     try {
       const res = await $fetch(requestUrl)
-      streamStats.value = res[segmentId.value]['stats']
+      streamStats.value = res
     } finally {
       isLoading.value = false
     }

--- a/webapp/types/modelsScenarios.ts
+++ b/webapp/types/modelsScenarios.ts
@@ -7,7 +7,7 @@ export const lcs: Record<lcsType, string> = {
 
 type Model =
   | 'ACCESS1-0'
-  | 'bcc-csm1-1'
+  | 'BCC-CSM1-1'
   | 'BNU-ESM'
   | 'CCSM4'
   | 'GFDL-ESM2G'
@@ -21,9 +21,9 @@ type Model =
   | 'NorESM1-M'
 
 export const models: Record<Model, string> = {
-  'ACCESS1-0': 'ACCESS1-0',
-  'bcc-csm1-1': 'BCC-CSM1-1',
-  'BNU-ESM': 'BNU-ESM',
+  'ACCESS1-0': 'ACCESS1-0', // does not have RCP 2.6 or 6.0
+  'BCC-CSM1-1': 'BCC-CSM1-1',
+  'BNU-ESM': 'BNU-ESM', // does not have RCP 2.6 or 6.0
   CCSM4: 'CCSM4',
   'GFDL-ESM2G': 'GFDL-ESM2G',
   'GFDL-ESM2M': 'GFDL-ESM2M',
@@ -36,19 +36,18 @@ export const models: Record<Model, string> = {
   'NorESM1-M': 'NorESM1-M',
 }
 
-type Scenario = 'rcp26' | 'rcp45' | 'rcp60' | 'rcp85'
+type Scenario = 'rcp45' | 'rcp60' | 'rcp85'
 
 export const scenarios: Record<Scenario, string> = {
-  rcp26: 'RCP 2.6',
   rcp45: 'RCP 4.5',
   rcp60: 'RCP 6.0',
   rcp85: 'RCP 8.5',
 }
 
-type Era = '2016_2045' | '2046_2075' | '2071_2100'
+type Era = '2016-2045' | '2046-2075' | '2071-2100'
 
 export const eras: Record<Era, string> = {
-  '2016_2045': '2016-2045',
-  '2046_2075': '2046-2075',
-  '2071_2100': '2071-2100',
+  '2016-2045': '2016-2045',
+  '2046-2075': '2046-2075',
+  '2071-2100': '2071-2100',
 }


### PR DESCRIPTION
This PR:

- modifies the fit-and-finish between the front-end and the new backend stats endpoint structure,
- removes RCP2.6 from the GUI
- makes CCSM4 RCP60 the default combo for now.

Known wont-fix: ACCESS1-0 and BNU-ESM don't have RCP2.6/6.0 so the app will break if you choose that combo. Ignore.

Testing: click on a stream segment and check the combos of model/scenarios. Thrill when you pick a breaking combo. Note that RCP2.6 isn't in the app anymore.
