### PR TITLE
Consolidate the Loading component into a single place

### DIFF
--- a/webapp/components/Loading.vue
+++ b/webapp/components/Loading.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { useStreamSegmentStore } from '~/stores/streamSegment'
+const streamSegmentStore = useStreamSegmentStore()
+let { streamStats, segmentName, isLoading } = storeToRefs(streamSegmentStore)
+</script>
+<template>
+	<div v-if="isLoading == true" class="loading content is-size-4">
+		<p>Loading data&hellip; this can take a minute or two.</p>
+		<progress class="progress" />
+	</div>
+</template>

--- a/webapp/components/Report.vue
+++ b/webapp/components/Report.vue
@@ -3,7 +3,7 @@ import { lcs, models, scenarios, eras } from '~/types/modelsScenarios'
 import { statVars } from '~/types/statsVars'
 import { useStreamSegmentStore } from '~/stores/streamSegment'
 const streamSegmentStore = useStreamSegmentStore()
-let { streamStats, segmentName, isLoading } = storeToRefs(streamSegmentStore)
+let { streamStats, segmentName } = storeToRefs(streamSegmentStore)
 
 const lcInput = defineModel('lc', { default: 'dynamic' })
 const modelInput = defineModel('model', { default: 'CCSM4' })
@@ -14,11 +14,8 @@ const scenarioInput = defineModel('scenario', { default: 'rcp60' })
   <VizHydrograph />
   <section class="section report">
     <div class="container">
-      <div v-if="isLoading == true" class="loading content is-size-4">
-        <p>Loading data&hellip; this can take a minute or two.</p>
-        <progress class="progress" />
-      </div>
-      <div v-if="!isLoading && streamStats">
+      <Loading />
+      <div v-if="streamStats">
         <h3
           class="title is-3 is-flex is-justify-content-center is-align-items-center mt-6 mb-5"
         >

--- a/webapp/components/Viz/Hydrograph.vue
+++ b/webapp/components/Viz/Hydrograph.vue
@@ -10,12 +10,7 @@ import type { Data } from 'plotly.js-dist-min'
 
 var plotlyChart // will have the Plotly object if value
 const streamSegmentStore = useStreamSegmentStore()
-let { streamHydrograph, segmentName, isLoading } =
-  storeToRefs(streamSegmentStore)
-
-// const lcInput = defineModel('lc', { default: 'dynamic' })
-// const modelInput = defineModel('model', { default: 'CCSM4' })
-// const scenarioInput = defineModel('scenario', { default: 'rcp60' })
+let { streamHydrograph, segmentName } = storeToRefs(streamSegmentStore)
 
 // Round to significant digits.  Stub.
 function roundTo(num, sig = 3) {
@@ -239,11 +234,7 @@ watch(streamHydrograph, newValue => {
 <template>
   <section class="section">
     <div class="container">
-      <div v-if="isLoading == true" class="loading content is-size-4">
-        <p>Loading data&hellip; this can take a minute or two.</p>
-        <progress class="progress" />
-      </div>
-      <div v-show="!isLoading && streamHydrograph" class="content">
+      <div v-show="streamHydrograph" class="content">
         <h3 class="title is-3">Hydrograph for {{ segmentName }}</h3>
         <ClientOnly>
           <div id="hydrograph"></div>


### PR DESCRIPTION
This just de-dupes and makes a single Loading component.

Testing:
- Run the app + run a local API / configure the app to point at the local API
- Load a place, observe that the Loading is shown/hidden (and there's only one, not two!)