### PR TITLE
Set fillOpacity of CONUS perimeter to 0 to avoid flash-of-blue on load

### DIFF
--- a/webapp/components/Map.vue
+++ b/webapp/components/Map.vue
@@ -80,6 +80,7 @@ const initializeMap = () => {
     .geoJSON(conusPerimeter, {
       style: {
         opacity: 0,
+        fillOpacity: 0,
         interactive: true,
       },
       onEachFeature: function (feature, layer) {


### PR DESCRIPTION
This is the GeoJSON layer that controls where you can click-to-zoom at low zoom levels. It's supposed to be invisible, but I'd set `opacity` to 0 without also setting `fillOpacity` to 0 and it colors the entire CONUS blue before the choropleth loads. Self-merging because this is a trivial change.