### PR TITLE
Limit API response to only the data needed for visible charts and tables

### DIFF
--- a/webapp/stores/streamSegment.ts
+++ b/webapp/stores/streamSegment.ts
@@ -54,8 +54,8 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamHydrograph.value = null
     var statsResponse, hydrographResponse
 
-    let statsRequestUrl = `${$config.public.snapApiUrl}/conus_hydrology/stats/${segmentId.value}`
-    let hydrographRequestUrl = `${$config.public.snapApiUrl}/conus_hydrology/modeled_climatology/${segmentId.value}`
+    let statsRequestUrl = `${$config.public.snapApiUrl}/conus_hydrology/stats/${segmentId.value}?models=Maurer,CCSM4`
+    let hydrographRequestUrl = `${$config.public.snapApiUrl}/conus_hydrology/modeled_climatology/${segmentId.value}?models=Maurer,CCSM4`
 
     // Needs error checking, etc.
     isLoading.value = true


### PR DESCRIPTION
Xref: https://github.com/ua-snap/hydroviz/issues/98
Xref: https://github.com/ua-snap/hydroviz/issues/86

See the corresponding PR in the Data API repo (https://github.com/ua-snap/data-api/pull/702). With the changes to the Data API, we're able to request only the data needed to populate the current set of charts and tables, reducing API data download by a factor of about 10x.

If/when we add a model selection dropdown back to the webapp, we can add a watcher to the dropdown selection event to request data for whatever model was chosen, similar to the ARDAC Explorer CMIP6 data x-ray items.