### PR TITLE
Use plotly.js-basic-dist-min instead of plotly.js-dist-min for significantly reduced library size

### DIFF
--- a/webapp/components/Viz/Hydrograph.vue
+++ b/webapp/components/Viz/Hydrograph.vue
@@ -3,7 +3,7 @@ import { toRaw } from 'vue'
 import lowess from '@stdlib/stats-lowess'
 import { getLayout, getConfig, initializeChart } from '~/utils/chart'
 const { $Plotly, $_ } = useNuxtApp()
-import type { Data } from 'plotly.js-dist-min'
+import type { Data } from 'plotly.js-basic-dist-min'
 
 const props = defineProps(['streamHydrograph'])
 

--- a/webapp/components/Viz/MonthlyFlow.vue
+++ b/webapp/components/Viz/MonthlyFlow.vue
@@ -2,7 +2,7 @@
 import { watch, toRaw } from 'vue'
 import { getLayout, getConfig, initializeChart } from '~/utils/chart'
 const { $Plotly, $_ } = useNuxtApp()
-import type { Data } from 'plotly.js-dist-min'
+import type { Data } from 'plotly.js-basic-dist-min'
 
 const props = defineProps(['streamStats'])
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -14,7 +14,7 @@
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
         "nuxt": "^4.2.2",
-        "plotly.js-dist-min": "^3.3.1",
+        "plotly.js-basic-dist-min": "^3.4.0",
         "vue": "latest",
         "vue-router": "latest"
       },
@@ -11109,10 +11109,10 @@
         "pathe": "^2.0.3"
       }
     },
-    "node_modules/plotly.js-dist-min": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-3.3.1.tgz",
-      "integrity": "sha512-ZxKM9DlEoEF3wBzGRPGHt6gWTJrm5N81J9AgX9UBX/Qjc9L4lRxtPBPq+RmBJWoA71j1X5Z1ouuguLkdoo88tg==",
+    "node_modules/plotly.js-basic-dist-min": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-3.4.0.tgz",
+      "integrity": "sha512-ZZgnlcwy4R0IBgrrTha0IDhVERQUTzneAVUB0v8S/myjJvCjpNnqIm4lYAdeK3kPg68Jf8LV2x92BWBOJPP/pw==",
       "license": "MIT"
     },
     "node_modules/postcss": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -17,7 +17,7 @@
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
     "nuxt": "^4.2.2",
-    "plotly.js-dist-min": "^3.3.1",
+    "plotly.js-basic-dist-min": "^3.4.0",
     "vue": "latest",
     "vue-router": "latest"
   },

--- a/webapp/plugins/plotly.client.ts
+++ b/webapp/plugins/plotly.client.ts
@@ -1,4 +1,4 @@
-import Plotly from 'plotly.js-dist-min'
+import Plotly from 'plotly.js-basic-dist-min'
 
 export default defineNuxtPlugin(nuxtApp => {
   return {

--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -1,4 +1,4 @@
-import type { Config, Layout } from 'plotly.js-dist-min'
+import type { Config, Layout } from 'plotly.js-basic-dist-min'
 
 export const getConfig = (filename: string): Partial<Config> => ({
   responsive: true, // changes the height / width dynamically for charts


### PR DESCRIPTION
Xref #98.

This PR replaces the full [plotly.js-dist-min](https://www.npmjs.com/package/plotly.js-dist-min) Plotly.js bundle with the [plotly.js-basic-dist-min](https://www.npmjs.com/package/plotly.js-basic-dist-min) bundle, which is an official release with support for bar, pie, and scatter plots. Fortunately, this covers all of the charts in the hydroviz application.

While running `npm run dev`, this shrinks the Plotly.js library from 7.4mb down to 1.7mb. It's harder to measure after an `npm run generate`, but shaves at least 2mb off of the combined and compiled JavaScript bundle size, bringing the initial application page load down from 6.2mb to 4.2mb of total network download traffic in my local testing.

To test, run:

```
git checkout shrink_plotly
npm install
npm run dev
```

And make sure everything works the same as before.