### PR TITLE
Fix chart margins, prevent cropping of titles

### DIFF
--- a/webapp/components/Viz/MonthlyFlow.vue
+++ b/webapp/components/Viz/MonthlyFlow.vue
@@ -2,7 +2,7 @@
 import { watch, toRaw } from 'vue'
 import { getLayout, getConfig, initializeChart } from '~/utils/chart'
 const { $Plotly, $_ } = useNuxtApp()
-import type { Data } from 'plotly.js-dist-min'
+import type { Data } from 'plotly.js-basic-dist-min'
 
 const props = defineProps(['streamStats'])
 


### PR DESCRIPTION
Closes #60.

This PR fixes the issue where chart titles were getting cropped at the top for each chart type. It also makes the chart margins more balanced, which is very evident in exported PNG charts. Self-merging this PR because it is a trivial change.