### PR TITLE
Add support for USGS gauge ID and HUC-8 IDs to search, not just their names

### DIFF
--- a/webapp/components/Search.vue
+++ b/webapp/components/Search.vue
@@ -11,7 +11,7 @@ onMounted(() => {
         // Escape single quotes for safe use inside CQL string literals
         const safeQuery = query.replace(/'/g, "''")
         const segUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Aseg_h8_outlet_stats_simplified&outputFormat=application%2Fjson&srsName=EPSG:4326&propertyName=seg_id_nat,GNIS_NAME,GAUGE_ID&cql_filter=GNIS_NAME%20ILIKE%20%27%25${safeQuery}%25%27%20OR%20GAUGE_ID%20ILIKE%20%27%25${safeQuery}%25%27`
-        const hucUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Ahuc8_conus_stats_simplified&outputFormat=application%2Fjson&srsName=EPSG:4326&propertyName=huc8,name&cql_filter%3Dname%20ILIKE%20%27%25${safeQuery}%25%27%20OR%20huc8%20LIKE%20%27%25${safeQuery}%25%27`
+        const hucUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Ahuc8_conus_stats_simplified&outputFormat=application%2Fjson&srsName=EPSG:4326&propertyName=huc8,name&cql_filter=name%20ILIKE%20%27%25${safeQuery}%25%27%20OR%20huc8%20LIKE%20%27%25${safeQuery}%25%27`
 
         let items: any[] = []
 


### PR DESCRIPTION
Closes #109.

This PR tweaks the search bar a little bit to allow:

- Search by USGS gauge ID, when available
- Search by HUC-8 ID

Without this change, it's only possibly to search by their names, not IDs.

To test, run the webapp like normal and then try searching for a USGS gauge ID and a HUC-8 ID. Here are a couple examples:

- USGS-05389400
- 17120008