### PR TITLE
Populate hydrograph and monthly flow charts based on "mid" or "extremes" mode

### DIFF
--- a/webapp/components/Report.vue
+++ b/webapp/components/Report.vue
@@ -37,7 +37,7 @@ onUnmounted(() => {
           Statistics for {{ segmentName }}
           <span class="segmentId">ID{{ segmentId }}</span>
         </h3>
-        <!-- <ReportMap class="my-6" /> -->
+        <ReportMap class="my-6" />
         <div class="content is-size-5">
           Introduction to the report goes here. We can pull some summarized info
           about the specific stream segment in order to highlight aspects of
@@ -58,31 +58,31 @@ onUnmounted(() => {
       <div class="container">
         <h4 class="title is-4">Magnitude statistics</h4>
         <VizMonthlyFlow :stream-monthly-flow="streamMonthlyFlow" />
-        <!-- <StatsTable :stream-stats="streamStats" category="magnitude" /> -->
+        <StatsTable :stream-stats="streamStats" category="magnitude" />
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Frequency statistics</h4>
-        <!-- <StatsTable :stream-stats="streamStats" category="frequency" /> -->
+        <StatsTable :stream-stats="streamStats" category="frequency" />
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Duration statistics</h4>
-        <!-- <StatsTable :stream-stats="streamStats" category="duration" /> -->
+        <StatsTable :stream-stats="streamStats" category="duration" />
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Timing statistics</h4>
-        <!-- <StatsTable :stream-stats="streamStats" category="timing" /> -->
+        <StatsTable :stream-stats="streamStats" category="timing" />
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Rate of change statistics</h4>
-        <!-- <StatsTable :stream-stats="streamStats" category="rate_of_change" /> -->
+        <StatsTable :stream-stats="streamStats" category="rate_of_change" />
       </div>
     </section>
   </div>

--- a/webapp/components/Report.vue
+++ b/webapp/components/Report.vue
@@ -37,7 +37,7 @@ onUnmounted(() => {
           Statistics for {{ segmentName }}
           <span class="segmentId">ID{{ segmentId }}</span>
         </h3>
-        <ReportMap class="my-6" />
+        <!-- <ReportMap class="my-6" /> -->
         <div class="content is-size-5">
           Introduction to the report goes here. We can pull some summarized info
           about the specific stream segment in order to highlight aspects of
@@ -58,31 +58,31 @@ onUnmounted(() => {
       <div class="container">
         <h4 class="title is-4">Magnitude statistics</h4>
         <VizMonthlyFlow :stream-monthly-flow="streamMonthlyFlow" />
-        <StatsTable :stream-stats="streamStats" category="magnitude" />
+        <!-- <StatsTable :stream-stats="streamStats" category="magnitude" /> -->
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Frequency statistics</h4>
-        <StatsTable :stream-stats="streamStats" category="frequency" />
+        <!-- <StatsTable :stream-stats="streamStats" category="frequency" /> -->
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Duration statistics</h4>
-        <StatsTable :stream-stats="streamStats" category="duration" />
+        <!-- <StatsTable :stream-stats="streamStats" category="duration" /> -->
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Timing statistics</h4>
-        <StatsTable :stream-stats="streamStats" category="timing" />
+        <!-- <StatsTable :stream-stats="streamStats" category="timing" /> -->
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Rate of change statistics</h4>
-        <StatsTable :stream-stats="streamStats" category="rate_of_change" />
+        <!-- <StatsTable :stream-stats="streamStats" category="rate_of_change" /> -->
       </div>
     </section>
   </div>

--- a/webapp/components/Viz/Hydrograph.vue
+++ b/webapp/components/Viz/Hydrograph.vue
@@ -20,10 +20,6 @@ onMounted(() => {
   )
 })
 
-watch(props.streamHydrograph, newValue => {
-  initializeChart($Plotly, 'hydrograph', buildChart, toRaw(newValue))
-})
-
 watch(appContext, () => {
   initializeChart(
     $Plotly,

--- a/webapp/components/Viz/Hydrograph.vue
+++ b/webapp/components/Viz/Hydrograph.vue
@@ -7,6 +7,10 @@ import type { Data } from 'plotly.js'
 
 const props = defineProps(['streamHydrograph'])
 
+import { useStreamSegmentStore } from '~/stores/streamSegment'
+const streamSegmentStore = useStreamSegmentStore()
+let { appContext } = storeToRefs(streamSegmentStore)
+
 onMounted(() => {
   initializeChart(
     $Plotly,
@@ -18,6 +22,15 @@ onMounted(() => {
 
 watch(props.streamHydrograph, newValue => {
   initializeChart($Plotly, 'hydrograph', buildChart, toRaw(newValue))
+})
+
+watch(appContext, () => {
+  initializeChart(
+    $Plotly,
+    'hydrograph',
+    buildChart,
+    toRaw(props.streamHydrograph)
+  )
 })
 
 // Round to significant digits.  Stub.
@@ -107,9 +120,7 @@ const buildChart = hg => {
     name: 'Historical Mean (Modeled), 1976-2005',
   })
 
-  // There's a gotcha here: two scenarios (ACCESS1-0, BNU-ESM) don't have RCP 2.6 or 6.0.
-  // Historical needs to have been removed.
-  let projectedFlowData = hg['projected']
+  let projectedFlowData = hg['projected'][appContext.value]
 
   let traceConfig = {
     doy_min: {

--- a/webapp/components/Viz/MonthlyFlow.vue
+++ b/webapp/components/Viz/MonthlyFlow.vue
@@ -59,7 +59,7 @@ const buildChart = () => {
     return historicalFlowData[monthKey]
   })
 
-  let projectedFlowData
+  let projectedFlowData: number[]
   if (appContext.value === 'mid') {
     projectedFlowData = []
     Object.keys(monthLabels).forEach(monthKey => {

--- a/webapp/components/Viz/MonthlyFlow.vue
+++ b/webapp/components/Viz/MonthlyFlow.vue
@@ -34,10 +34,6 @@ onMounted(() => {
   )
 })
 
-watch(props.streamMonthlyFlow, newValue => {
-  initializeChart($Plotly, 'monthly-flow', buildChart, toRaw(newValue))
-})
-
 watch(appContext, () => {
   initializeChart(
     $Plotly,

--- a/webapp/components/Viz/MonthlyFlow.vue
+++ b/webapp/components/Viz/MonthlyFlow.vue
@@ -6,6 +6,10 @@ import type { Data } from 'plotly.js'
 
 const props = defineProps(['streamMonthlyFlow'])
 
+import { useStreamSegmentStore } from '~/stores/streamSegment'
+const streamSegmentStore = useStreamSegmentStore()
+let { appContext } = storeToRefs(streamSegmentStore)
+
 const monthLabels = {
   ma21: 'Oct',
   ma22: 'Nov',
@@ -34,6 +38,15 @@ watch(props.streamMonthlyFlow, newValue => {
   initializeChart($Plotly, 'monthly-flow', buildChart, toRaw(newValue))
 })
 
+watch(appContext, () => {
+  initializeChart(
+    $Plotly,
+    'monthly-flow',
+    buildChart,
+    toRaw(props.streamMonthlyFlow)
+  )
+})
+
 // stats is assumed to be non-null, raw, and only dynamic land cover now.
 const buildChart = () => {
   let traces: Data[] = []
@@ -46,28 +59,53 @@ const buildChart = () => {
     return historicalFlowData[monthKey]
   })
 
-  // Historical needs to have been removed.
-  let projectedFlowData = props.streamMonthlyFlow['projected']
-
-  // Each box plot needs to be its own trace (due to Plotly.js limitations),
-  // and a new legend entry is added for each trace. To clean this up, show
-  // the legend for just the first box plot trace, hide the rest, and override
-  // the name of the first legend entry to make it more general & apply to all
-  // of the box plots. Also, make sure all box plots have the same color.
-  let showLegend = true
-  Object.keys(monthLabels).forEach(monthKey => {
-    traces.push({
-      x: Array(projectedFlowData[monthKey].length).fill(monthLabels[monthKey]),
-      y: projectedFlowData[monthKey],
-      type: 'box',
-      name: 'Projected (Modeled), 2046-2075',
-      marker: { color: '#3182bd' },
-      line: { color: '#3182bd', width: 1.5 },
-      fillcolor: '#6baed6',
-      showlegend: showLegend,
+  let projectedFlowData
+  if (appContext.value === 'mid') {
+    projectedFlowData = []
+    Object.keys(monthLabels).forEach(monthKey => {
+      projectedFlowData.push(
+        props.streamMonthlyFlow['projected'][appContext.value][monthKey]
+      )
     })
-    showLegend = false
-  })
+  } else {
+    projectedFlowData = props.streamMonthlyFlow['projected'][appContext.value]
+  }
+
+  // For "extremes" mode, show a boxplot populated by all values across all models
+  // and scenarios for each month. For "mid" mode, show a single point of the mean
+  // of all models at RCP 6.0 for each month.
+  if (appContext.value === 'extremes') {
+    // Each box plot needs to be its own trace (due to Plotly.js limitations),
+    // and a new legend entry is added for each trace. To clean this up, show
+    // the legend for just the first box plot trace, hide the rest, and override
+    // the name of the first legend entry to make it more general & apply to all
+    // of the box plots. Also, make sure all box plots have the same color.
+    let showLegend = true
+    Object.keys(monthLabels).forEach(monthKey => {
+      traces.push({
+        x: Array(projectedFlowData[monthKey].length).fill(
+          monthLabels[monthKey]
+        ),
+        y: projectedFlowData[monthKey],
+        type: 'box',
+        name: 'Projected (Modeled), 2046-2075',
+        marker: { color: '#3182bd', size: 8 },
+        line: { color: '#3182bd', width: 1.5 },
+        fillcolor: '#6baed6',
+        showlegend: showLegend,
+      })
+      showLegend = false
+    })
+  } else {
+    traces.push({
+      x: Object.values(monthLabels),
+      y: projectedFlowData,
+      type: 'scatter',
+      mode: 'markers',
+      name: 'Projected (Modeled), 2046-2075',
+      marker: { color: '#3182bd', size: 8 },
+    })
+  }
 
   let monthMarkers = Object.values(monthLabels)
   traces.push({
@@ -78,11 +116,12 @@ const buildChart = () => {
     name: 'Historical (Modeled), 1976-2005',
     marker: {
       size: 8,
+      symbol: 'square',
       color: '#666666',
     },
   })
 
-  const titleText: string = 'Mean monthly modeled flow rate, RCP 8.5'
+  const titleText: string = 'Mean monthly modeled flow rate'
 
   const layout = getLayout(titleText, 'Mean monthly flow, cf/s', {
     type: 'category',

--- a/webapp/stores/streamSegment.ts
+++ b/webapp/stores/streamSegment.ts
@@ -61,7 +61,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamStats.value = null
     var dataResponse
 
-    let dataUrl = `${$config.public.snapApiUrl}/conus_hydrology/hydroviz/${segmentId.value}/CCSM4`
+    let dataUrl = `${$config.public.snapApiUrl}/conus_hydrology/hydroviz/${segmentId.value}`
 
     // Needs error checking, etc.
     isLoading.value = true


### PR DESCRIPTION
Xref: https://github.com/ua-snap/data-api/pull/709

This PR works with the `aggregate_hydroviz_endpoints` branch of the Data API to make the hydrograph and monthly flow charts react to the mid/extreme toggle in the following ways:

- In "extremes" mode, the hydrography shows the max/mean/min values across all CMIP5 models and scenarios (excluding RCP 2.6). In "mid" mode, it shows the max/mean/min across all CMIP5 models for just the RCP 6.0 scenario.
- In "extremes" mode, the monthly flow chart shows box plots populated with an array of values across all CMIP5 models and scenarios (excluding RCP 2.6). In "mid" mode, it shows a single mean value for each month (i.e., just a scatter marker, not a boxplot) which represents the mean value across all CMIP5 models for the RCP 6.0 scenario.

Testing is a little tricky since the `StatsTable` code hasn't been updated to work with the new API response structure in this branch, causing the report page to not to load properly. To run this branch, you'll need to comment out all references to the `StatsTable` component. I.e., comment out every line like this in `Report.vue` to test:

```
<StatsTable ... />
```