### PR TITLE
Make HUC-8 outlet segments stand out more on report page

### DIFF
--- a/webapp/components/Map.vue
+++ b/webapp/components/Map.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { $L, $config } = useNuxtApp()
+import { getHandleCoord } from '~/utils/map'
 
 const segBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Aseg_h8_outlet_stats_simplified&outputFormat=application%2Fjson&srsName=EPSG:4326&cql_filter=`
 const hucBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Ahuc8&outputFormat=application%2Fjson&srsName=EPSG:4326&cql_filter=huc8=`
@@ -206,11 +207,8 @@ const addSegmentsGeoJson = async (data: any) => {
       })
       .addTo(map)
 
-    // Extract the first coordinate to place the handle.
-    let firstCoord = feature.geometry.coordinates[0][0]
-    let latlng = $L.latLng(firstCoord[1], firstCoord[0])
-
     // Add a circle marker as a handle.
+    let latlng = getHandleCoord(feature)
     let handle = $L
       .circleMarker(latlng, {
         radius: 4,

--- a/webapp/components/ReportMap.vue
+++ b/webapp/components/ReportMap.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 const { $L, $config } = useNuxtApp()
 import { useStreamSegmentStore } from '~/stores/streamSegment'
+import { getHandleCoord } from '~/utils/map'
 const streamSegmentStore = useStreamSegmentStore()
 let { hucId } = storeToRefs(streamSegmentStore)
 
@@ -8,11 +9,6 @@ const hucBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&ver
 const segBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Aseg_h8_outlet_stats_simplified&outputFormat=application%2Fjson&srsName=EPSG:4326&cql_filter=`
 
 let map: any = null
-
-const getHandleCoord = (feature: any) => {
-  let firstCoord = feature.geometry.coordinates[0][0]
-  return $L.latLng(firstCoord[1], firstCoord[0])
-}
 
 const addHuc = () => {
   let hucUrl = hucBaseUrl + hucId.value

--- a/webapp/utils/map.ts
+++ b/webapp/utils/map.ts
@@ -1,0 +1,5 @@
+export const getHandleCoord = (feature: any) => {
+  const { $L } = useNuxtApp()
+  let firstCoord = feature.geometry.coordinates[0][0]
+  return $L.latLng(firstCoord[1], firstCoord[0])
+}


### PR DESCRIPTION
Closes #114.

This PR makes outlet segments stand out better in the minimap on report pages for HUC-8s by doing the following:

- Adds outlet segments to the map after regular segments, effectively giving them a higher z-index.
- Adds a pin marker to the first lat/lon of the outlet segment.
- Reduces the opacity of the WMS base layer to 75% to make the line segments (and their colors) stand out better.
- Adds circle "handles" to all outlet & non-outlet line segments for consistency with the front page map (and it also makes the colors pop a bit more).

This also works just fine with HUC-8s that have multiple outlet segments. Example:
http://localhost:3000/huc/04110003

To test, run the app against the current `main` branch of the Data API and try loading report pages for various HUC-8s by searching for them in the search bar (searching for random strings of numbers tends to find HUC-8 results better than random words... or search for "north" or "south").