### PR TITLE
Add min/max annual flow & date polarscatter chart with mid & extremes mode

### DIFF
--- a/webapp/components/Report.vue
+++ b/webapp/components/Report.vue
@@ -5,6 +5,7 @@ let {
   streamStats,
   streamHydrograph,
   streamMonthlyFlow,
+  streamMinMaxFlowDates,
   hucId,
   segmentId,
   segmentName,
@@ -37,7 +38,7 @@ onUnmounted(() => {
           Statistics for {{ segmentName }}
           <span class="segmentId">ID{{ segmentId }}</span>
         </h3>
-        <ReportMap class="my-6" />
+        <!-- <ReportMap class="my-6" /> -->
         <div class="content is-size-5">
           Introduction to the report goes here. We can pull some summarized info
           about the specific stream segment in order to highlight aspects of
@@ -51,38 +52,41 @@ onUnmounted(() => {
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Hydrograph</h4>
-        <VizHydrograph :stream-hydrograph="streamHydrograph" />
+        <!-- <VizHydrograph :stream-hydrograph="streamHydrograph" /> -->
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Magnitude statistics</h4>
-        <VizMonthlyFlow :stream-monthly-flow="streamMonthlyFlow" />
-        <StatsTable :stream-stats="streamStats" category="magnitude" />
+        <!-- <VizMonthlyFlow :stream-monthly-flow="streamMonthlyFlow" /> -->
+        <VizMinMaxFlowDates
+          :stream-min-max-flow-dates="streamMinMaxFlowDates"
+        />
+        <!-- <StatsTable :stream-stats="streamStats" category="magnitude" /> -->
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Frequency statistics</h4>
-        <StatsTable :stream-stats="streamStats" category="frequency" />
+        <!-- <StatsTable :stream-stats="streamStats" category="frequency" /> -->
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Duration statistics</h4>
-        <StatsTable :stream-stats="streamStats" category="duration" />
+        <!-- <StatsTable :stream-stats="streamStats" category="duration" /> -->
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Timing statistics</h4>
-        <StatsTable :stream-stats="streamStats" category="timing" />
+        <!-- <StatsTable :stream-stats="streamStats" category="timing" /> -->
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Rate of change statistics</h4>
-        <StatsTable :stream-stats="streamStats" category="rate_of_change" />
+        <!-- <StatsTable :stream-stats="streamStats" category="rate_of_change" /> -->
       </div>
     </section>
   </div>

--- a/webapp/components/Report.vue
+++ b/webapp/components/Report.vue
@@ -38,7 +38,7 @@ onUnmounted(() => {
           Statistics for {{ segmentName }}
           <span class="segmentId">ID{{ segmentId }}</span>
         </h3>
-        <!-- <ReportMap class="my-6" /> -->
+        <ReportMap class="my-6" />
         <div class="content is-size-5">
           Introduction to the report goes here. We can pull some summarized info
           about the specific stream segment in order to highlight aspects of
@@ -52,41 +52,41 @@ onUnmounted(() => {
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Hydrograph</h4>
-        <!-- <VizHydrograph :stream-hydrograph="streamHydrograph" /> -->
+        <VizHydrograph :stream-hydrograph="streamHydrograph" />
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Magnitude statistics</h4>
-        <!-- <VizMonthlyFlow :stream-monthly-flow="streamMonthlyFlow" /> -->
-        <VizMinMaxFlowDates
-          :stream-min-max-flow-dates="streamMinMaxFlowDates"
-        />
-        <!-- <StatsTable :stream-stats="streamStats" category="magnitude" /> -->
+        <VizMonthlyFlow :stream-monthly-flow="streamMonthlyFlow" />
+        <StatsTable :stream-stats="streamStats" category="magnitude" />
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Frequency statistics</h4>
-        <!-- <StatsTable :stream-stats="streamStats" category="frequency" /> -->
+        <StatsTable :stream-stats="streamStats" category="frequency" />
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Duration statistics</h4>
-        <!-- <StatsTable :stream-stats="streamStats" category="duration" /> -->
+        <StatsTable :stream-stats="streamStats" category="duration" />
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Timing statistics</h4>
-        <!-- <StatsTable :stream-stats="streamStats" category="timing" /> -->
+        <VizMinMaxFlowDates
+          :stream-min-max-flow-dates="streamMinMaxFlowDates"
+        />
+        <StatsTable :stream-stats="streamStats" category="timing" />
       </div>
     </section>
     <section class="section">
       <div class="container">
         <h4 class="title is-4">Rate of change statistics</h4>
-        <!-- <StatsTable :stream-stats="streamStats" category="rate_of_change" /> -->
+        <StatsTable :stream-stats="streamStats" category="rate_of_change" />
       </div>
     </section>
   </div>

--- a/webapp/components/StickyToggle.vue
+++ b/webapp/components/StickyToggle.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useStreamSegmentStore } from '~/stores/streamSegment'
 const streamSegmentStore = useStreamSegmentStore()
-let { appContext } = storeToRefs(streamSegmentStore)
+let { appContext, appEra } = storeToRefs(streamSegmentStore)
 </script>
 
 <template>
@@ -40,8 +40,22 @@ let { appContext } = storeToRefs(streamSegmentStore)
         future extremes
       </label>
     </span>
-    in charts and graphs below.
-    <span>Value: {{ appContext }}</span>
+    in charts and graphs below.<br />
+    Show projected data for
+    <span class="control is-size-5">
+      <label class="radio">
+        <input type="radio" name="era" value="2016-2045" v-model="appEra" />
+        2016-2045 </label
+      >,
+      <label class="radio">
+        <input type="radio" name="era" value="2046-2075" v-model="appEra" />
+        2046-2075 </label
+      >, or
+      <label class="radio">
+        <input type="radio" name="era" value="2071-2100" v-model="appEra" />
+        2071-2100 </label
+      >.
+    </span>
   </div>
 </template>
 

--- a/webapp/components/Viz/Hydrograph.vue
+++ b/webapp/components/Viz/Hydrograph.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { toRaw } from 'vue'
 import lowess from '@stdlib/stats-lowess'
+import { doyToDateString } from '~/utils/general'
 import { getLayout, getConfig, initializeChart } from '~/utils/chart'
 const { $Plotly, $_ } = useNuxtApp()
 import type { Data } from 'plotly.js'
@@ -23,14 +24,6 @@ watch(props.streamHydrograph, newValue => {
 // Round to significant digits.  Stub.
 function roundTo(num, sig = 3) {
   return Number(num.toPrecision(sig))
-}
-
-const doyToDateString = (doy: number) => {
-  const year = 2025 // Can be any year, but not a leap year.
-  const date = new Date(year, 0) // January 1st of the given year
-  date.setDate(doy) // Add DOY as days offset
-  const options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' }
-  return date.toLocaleDateString('en-US', options)
 }
 
 // Shift a DOY-indexed dataset to hydro year (Oct 1 - Sept 30)

--- a/webapp/components/Viz/MinMaxFlowDates.vue
+++ b/webapp/components/Viz/MinMaxFlowDates.vue
@@ -7,7 +7,7 @@ import type { Data } from 'plotly.js'
 
 import { useStreamSegmentStore } from '~/stores/streamSegment'
 const streamSegmentStore = useStreamSegmentStore()
-const { appContext } = storeToRefs(streamSegmentStore)
+const { appContext, appEra } = storeToRefs(streamSegmentStore)
 
 const props = defineProps(['streamMinMaxFlowDates'])
 
@@ -20,7 +20,7 @@ onMounted(() => {
   )
 })
 
-watch(appContext, () => {
+watch([appContext, appEra], () => {
   initializeChart(
     $Plotly,
     'min-max-flow-dates',
@@ -37,9 +37,12 @@ const convertTo360 = (doy: number) => {
 
 const buildChart = () => {
   let allFlows = [props.streamMinMaxFlowDates['historical']['max']['flow']]
-  allFlows = allFlows.concat(
-    props.streamMinMaxFlowDates['projected']['extremes']['max']['flow']
-  )
+  let possibleEras = ['2016-2045', '2046-2075', '2071-2100']
+  possibleEras.forEach(era => {
+    allFlows = allFlows.concat(
+      props.streamMinMaxFlowDates['projected']['extremes'][era]['max']['flow']
+    )
+  })
   let upperLimit = $_.max(allFlows)
 
   let historicalTraces: Data[] = []
@@ -54,15 +57,14 @@ const buildChart = () => {
     ]
 
     let projectedFlows =
-      props.streamMinMaxFlowDates['projected'][appContext.value][stat]['flow']
+      props.streamMinMaxFlowDates['projected'][appContext.value][appEra.value][
+        stat
+      ]['flow']
     let projectedDates = $_.cloneDeep(
-      props.streamMinMaxFlowDates['projected'][appContext.value][stat]['date']
+      props.streamMinMaxFlowDates['projected'][appContext.value][appEra.value][
+        stat
+      ]['date']
     )
-
-    if (appContext.value === 'mid') {
-      projectedFlows = [projectedFlows]
-      projectedDates = [projectedDates]
-    }
 
     let customdataHistorical: string[][] = []
     historicalFlowDate.forEach((doy: number, index: number) => {
@@ -108,8 +110,9 @@ const buildChart = () => {
       mode: 'markers',
       name: historicalTraceLabel,
       marker: {
-        size: 8,
+        size: 9,
         color: historicalColor,
+        symbol: 'diamond',
       },
       customdata: customdataHistorical,
       hovertemplate: `%{customdata[0]}, 1976-2005<br />${historicalHovertextLabel}: %{r:,} cf/s<extra></extra>`,
@@ -123,7 +126,6 @@ const buildChart = () => {
       marker: {
         size: 8,
         color: projectedColor,
-        symbol: 'square',
       },
       customdata: customdataProjected,
       hovertemplate: `%{customdata[0]}, 2046-2075<br />${projectedHovertextLabel}: %{r:,} cf/s<extra></extra>`,

--- a/webapp/components/Viz/MinMaxFlowDates.vue
+++ b/webapp/components/Viz/MinMaxFlowDates.vue
@@ -172,7 +172,7 @@ const buildChart = () => {
     },
   }
 
-  const config = getConfig()
+  const config = getConfig('min-max-flow-dates')
 
   $Plotly.newPlot('min-max-flow-dates', traces, layout, config)
 }

--- a/webapp/components/Viz/MinMaxFlowDates.vue
+++ b/webapp/components/Viz/MinMaxFlowDates.vue
@@ -137,18 +137,18 @@ const buildChart = () => {
 
   const layout = getLayout(titleText, '')
 
-  let firstofMonthValues = [
+  let firstOfMonthValues = [
     1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335,
   ]
 
-  firstofMonthValues = firstofMonthValues.map((doy: number) => {
+  firstOfMonthValues = firstOfMonthValues.map((doy: number) => {
     return convertTo360(doy)
   })
 
   layout['polar'] = {
     angularaxis: {
       tickmode: 'array',
-      tickvals: firstofMonthValues,
+      tickvals: firstOfMonthValues,
       ticktext: [
         'Jan',
         'Feb',

--- a/webapp/components/Viz/MinMaxFlowDates.vue
+++ b/webapp/components/Viz/MinMaxFlowDates.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import { watch, toRaw } from 'vue'
+import { doyToDateString } from '~/utils/general'
+import { getLayout, getConfig, initializeChart } from '~/utils/chart'
+const { $Plotly, $_ } = useNuxtApp()
+import type { Data } from 'plotly.js'
+
+import { useStreamSegmentStore } from '~/stores/streamSegment'
+const streamSegmentStore = useStreamSegmentStore()
+const { appContext } = storeToRefs(streamSegmentStore)
+
+const props = defineProps(['streamMinMaxFlowDates'])
+
+onMounted(() => {
+  initializeChart(
+    $Plotly,
+    'min-max-flow-dates',
+    buildChart,
+    toRaw(props.streamMinMaxFlowDates)
+  )
+})
+
+watch(appContext, () => {
+  initializeChart(
+    $Plotly,
+    'min-max-flow-dates',
+    buildChart,
+    toRaw(props.streamMinMaxFlowDates)
+  )
+})
+
+// Values exceeding 360 cannot be plotted on a Plotly.js polarscatter chart.
+// So, slightly squeeze 366 calendar to a 360 degree representation.
+const convertTo360 = (doy: number) => {
+  return ((doy - 1) / 366) * 360
+}
+
+const buildChart = () => {
+  let allFlows = [props.streamMinMaxFlowDates['historical']['max']['flow']]
+  allFlows = allFlows.concat(
+    props.streamMinMaxFlowDates['projected']['extremes']['max']['flow']
+  )
+  let upperLimit = $_.max(allFlows)
+
+  let historicalTraces: Data[] = []
+  let projectedTraces: Data[] = []
+  let stats = ['min', 'max']
+  stats.forEach(stat => {
+    let historicalFlow = [
+      props.streamMinMaxFlowDates['historical'][stat]['flow'],
+    ]
+    let historicalFlowDate = [
+      convertTo360(props.streamMinMaxFlowDates['historical'][stat]['date']),
+    ]
+
+    let projectedFlows =
+      props.streamMinMaxFlowDates['projected'][appContext.value][stat]['flow']
+    let projectedDates = $_.cloneDeep(
+      props.streamMinMaxFlowDates['projected'][appContext.value][stat]['date']
+    )
+
+    if (appContext.value === 'mid') {
+      projectedFlows = [projectedFlows]
+      projectedDates = [projectedDates]
+    }
+
+    let customdataHistorical: string[][] = []
+    historicalFlowDate.forEach((doy: number, index: number) => {
+      let dayString = doyToDateString(
+        props.streamMinMaxFlowDates['historical'][stat]['date']
+      )
+
+      customdataHistorical.push([dayString])
+      historicalFlowDate[index] = convertTo360(doy)
+    })
+
+    let customdataProjected: string[][] = []
+    projectedDates.forEach((doy: number, index: number) => {
+      let dayString = doyToDateString(doy)
+      customdataProjected.push([dayString])
+      projectedDates[index] = convertTo360(doy)
+    })
+
+    let historicalTraceLabel: string
+    let projectedTraceLabel: string
+    let historicalColor: string
+    let projectedColor: string
+    let historicalHovertextLabel: string
+    let projectedHovertextLabel: string
+    if (stat === 'min') {
+      historicalTraceLabel = 'Minimum flow date, historical, 1976-2005'
+      projectedTraceLabel = 'Minimum flow date, modeled, 2046-2075'
+      historicalColor = '#aaaaaa'
+      projectedColor = '#6baed6'
+      historicalHovertextLabel = 'Min historical flow'
+      projectedHovertextLabel = 'Min projected flow'
+    } else {
+      historicalTraceLabel = 'Maximum flow date, historical, 1976-2005'
+      projectedTraceLabel = 'Maximum flow date, modeled, 2046-2075'
+      historicalColor = '#666666'
+      projectedColor = '#3182bd'
+      historicalHovertextLabel = 'Max historical flow'
+      projectedHovertextLabel = 'Max projected flow'
+    }
+
+    historicalTraces.push({
+      r: historicalFlow,
+      theta: historicalFlowDate,
+      type: 'scatterpolar',
+      mode: 'markers',
+      name: historicalTraceLabel,
+      marker: {
+        size: 8,
+        color: historicalColor,
+      },
+      customdata: customdataHistorical,
+      hovertemplate: `%{customdata[0]}, 1976-2005<br />${historicalHovertextLabel}: %{r:,} cf/s<extra></extra>`,
+    })
+    projectedTraces.push({
+      r: projectedFlows,
+      theta: projectedDates,
+      type: 'scatterpolar',
+      mode: 'markers',
+      name: projectedTraceLabel,
+      marker: {
+        size: 8,
+        color: projectedColor,
+        symbol: 'square',
+      },
+      customdata: customdataProjected,
+      hovertemplate: `%{customdata[0]}, 2046-2075<br />${projectedHovertextLabel}: %{r:,} cf/s<extra></extra>`,
+    })
+  })
+
+  let traces = historicalTraces.concat(projectedTraces)
+  const titleText = 'Minimum and maximum flow dates, cf/s'
+
+  const layout = getLayout(titleText, '')
+
+  let firstofMonthValues = [
+    1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335,
+  ]
+
+  firstofMonthValues = firstofMonthValues.map((doy: number) => {
+    return convertTo360(doy)
+  })
+
+  layout['polar'] = {
+    angularaxis: {
+      tickmode: 'array',
+      tickvals: firstofMonthValues,
+      ticktext: [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec',
+      ],
+      direction: 'clockwise',
+    },
+    radialaxis: {
+      range: [0, upperLimit],
+      angle: 90,
+      tickangle: 90,
+    },
+  }
+
+  const config = getConfig()
+
+  $Plotly.newPlot('min-max-flow-dates', traces, layout, config)
+}
+</script>
+
+<template>
+  <div id="min-max-flow-dates"></div>
+</template>

--- a/webapp/components/Viz/MinMaxFlowDates.vue
+++ b/webapp/components/Viz/MinMaxFlowDates.vue
@@ -50,7 +50,7 @@ const buildChart = () => {
       props.streamMinMaxFlowDates['historical'][stat]['flow'],
     ]
     let historicalFlowDate = [
-      convertTo360(props.streamMinMaxFlowDates['historical'][stat]['date']),
+      props.streamMinMaxFlowDates['historical'][stat]['date'],
     ]
 
     let projectedFlows =
@@ -66,9 +66,7 @@ const buildChart = () => {
 
     let customdataHistorical: string[][] = []
     historicalFlowDate.forEach((doy: number, index: number) => {
-      let dayString = doyToDateString(
-        props.streamMinMaxFlowDates['historical'][stat]['date']
-      )
+      let dayString = doyToDateString(doy)
 
       customdataHistorical.push([dayString])
       historicalFlowDate[index] = convertTo360(doy)

--- a/webapp/plugins/plotly.client.ts
+++ b/webapp/plugins/plotly.client.ts
@@ -1,8 +1,12 @@
 import Plotly from 'plotly.js/lib/core'
+
 import scatter from 'plotly.js/lib/scatter'
 import box from 'plotly.js/lib/box'
+import scatterpolar from 'plotly.js/lib/scatterpolar'
+
 Plotly.register(scatter)
 Plotly.register(box)
+Plotly.register(scatterpolar)
 
 export default defineNuxtPlugin(nuxtApp => {
   return {

--- a/webapp/stores/streamSegment.ts
+++ b/webapp/stores/streamSegment.ts
@@ -9,6 +9,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
   const streamSummary = shallowRef(null)
   const streamHydrograph = shallowRef(null)
   const streamMonthlyFlow = shallowRef(null)
+  const streamMinMaxFlowDates = shallowRef(null)
   const streamStats = shallowRef(null)
   const appContext = ref<AppContext>('mid')
   const { $config } = useNuxtApp()
@@ -58,10 +59,11 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamSummary.value = null
     streamHydrograph.value = null
     streamMonthlyFlow.value = null
+    streamMinMaxFlowDates.value = null
     streamStats.value = null
     var dataResponse
 
-    let dataUrl = `${$config.public.snapApiUrl}/conus_hydrology/hydroviz/${segmentId.value}/CCSM4`
+    let dataUrl = `${$config.public.snapApiUrl}/conus_hydrology/hydroviz/${segmentId.value}`
 
     // Needs error checking, etc.
     isLoading.value = true
@@ -80,6 +82,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamSummary.value = dataResponse['summary']
     streamHydrograph.value = dataResponse['hydrograph']
     streamMonthlyFlow.value = dataResponse['monthly_flow']
+    streamMinMaxFlowDates.value = dataResponse['min_max_flow_dates']
     streamStats.value = dataResponse['stats']
   }
 
@@ -89,6 +92,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamSummary.value = null
     streamHydrograph.value = null
     streamMonthlyFlow.value = null
+    streamMinMaxFlowDates.value = null
     streamStats.value = null
     hucId.value = null
   }
@@ -99,6 +103,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamSummary,
     streamHydrograph,
     streamMonthlyFlow,
+    streamMinMaxFlowDates,
     streamStats,
     fetchStreamStats,
     fetchHucStats,

--- a/webapp/stores/streamSegment.ts
+++ b/webapp/stores/streamSegment.ts
@@ -15,6 +15,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
   const streamMinMaxFlowDates = shallowRef(null)
   const streamStats = shallowRef(null)
   const appContext = ref<AppContext>('mid')
+  const appEra = ref<Era>('2046-2075')
   const { $config } = useNuxtApp()
 
   // If we have a hucId but not a segmentId, set segmentId to HUC outlet.
@@ -151,5 +152,6 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     apiSlow,
     apiFailed,
     appContext,
+    appEra,
   }
 })

--- a/webapp/utils/general.ts
+++ b/webapp/utils/general.ts
@@ -1,4 +1,12 @@
 // f)ormat n)umber with c)ommas
 export const fnc = (number: number): string => {
-	return new Intl.NumberFormat().format(number)
+  return new Intl.NumberFormat().format(number)
+}
+
+export const doyToDateString = (doy: number) => {
+  const year = 2025 // Can be any year, but not a leap year.
+  const date = new Date(year, 0) // January 1st of the given year
+  date.setDate(Math.round(doy)) // Add DOY as days offset
+  const options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' }
+  return date.toLocaleDateString('en-US', options)
 }


### PR DESCRIPTION
This PR implements a new `scatterpolar` type chart to plot the magnitude & date for min/max annual flow on a circular chart. It supports the "mid" and "extremes" mode toggle.

To test, run this against your local Data API on the `aggregate_hydroviz_endpoints` branch:

```
cd data-api
micromamba activate api-env
git checkout aggregate_hydroviz_endpoints
git pull --ff-only
flask run
```

```
cd hydroviz/webapp
export SNAP_API_URL=http://localhost:5000
git checkout max_flow_date_chart
npm run dev
```

Because this branch is based off of `main`, all of the other data-driven webapp components won't work because they are still attempting to use the old API response structure (we have a PR open to fix this for the hydrograph and monthly flow chart, https://github.com/ua-snap/hydroviz/pull/124). Unfortunately, this causes the whole report page to fail to load properly. So, to run this `max_flow_date_chart` branch, you'll need to comment out the following components in `Report.vue`:

- `<VizHydrograph ... />`
- `<VizMonthlyFlow ... />`
- `<StatsTable ... />`