### PR TITLE
Move historical marker above projected on polarscatter charts, and move era into title

### DIFF
--- a/webapp/components/Viz/MinMaxFlowDates.vue
+++ b/webapp/components/Viz/MinMaxFlowDates.vue
@@ -83,7 +83,7 @@ const buildChart = () => {
     })
 
     const historicalTraceLabel = 'Historical, 1976-2005'
-    const projectedTraceLabel = 'Projected, ' + appEra.value
+    const projectedTraceLabel = 'Projected'
     const historicalHovertextLabel = 'Max historical flow'
     const projectedHovertextLabel = 'Max projected flow'
 
@@ -162,8 +162,12 @@ const buildChart = () => {
     projectedTraces.push(trace)
   })
 
-  let traces = historicalTraces.concat(projectedTraces)
-  const titleText = 'Modeled flow rate at date of annual maximum daily flow'
+  // Reverse projected traces because the legend gets reversed later.
+  // This will ultimately keep the legend order the same as the subplot order.
+  projectedTraces.reverse()
+
+  let traces = projectedTraces.concat(historicalTraces)
+  const titleText = `Modeled flow rate at date of annual maximum daily flow, ${appEra.value}`
 
   let legendConfig = {
     orientation: 'h',
@@ -171,6 +175,7 @@ const buildChart = () => {
     y: -0.15,
     xanchor: 'center',
     x: 0.5,
+    traceorder: 'reversed',
   }
 
   const layout = getLayout(titleText, '', {}, {}, legendConfig)


### PR DESCRIPTION
Closes #152.
Closes #154.

This PR simply:

- Moves the historical scatter marker to a higher plane (effectively a higher z-index) on the "Modeled flow rate at date of annual maximum flow" polarscatter charts, and makes a few other small code changes to keep the legend in the same order.
- Moves the projected era out of the legend items and into the chart title to make this chart more consistent with the other chart types, and to keep the legend succinct.

To test, load a report page, scroll down to the polarscatter charts, and try switching between middle-of-the-road/extremes and different eras.