### PR TITLE
Add text above maps that outflow segments are red

### DIFF
--- a/webapp/components/Map.vue
+++ b/webapp/components/Map.vue
@@ -604,6 +604,14 @@ onMounted(() => {
 </script>
 
 <template>
+  <p
+    class="is-size-5 mb-2"
+    :style="{
+      visibility: currentPhase === MapPhase.HucSelected ? 'visible' : 'hidden',
+    }"
+  >
+    🔴 Watershed outflow segments in the map below are shown in red.
+  </p>
   <div class="map-wrapper" style="height: 80vh; min-height: 500px">
     <div :id="config.mapId" style="height: 100%"></div>
     <button

--- a/webapp/components/ReportMap.vue
+++ b/webapp/components/ReportMap.vue
@@ -85,9 +85,8 @@ onMounted(() => {
 </script>
 
 <template>
-  <p v-if="hucId" class="is-size-5 mb-2">
-    Outflow segments in the map below are
-    <strong style="color: #ff0000">red</strong>.
+  <p class="is-size-5 mb-2">
+    🔴 Watershed outflow segments in the map below are shown in red.
   </p>
   <div id="report-map" style="height: 400px" class="mb-6"></div>
 </template>

--- a/webapp/components/ReportMap.vue
+++ b/webapp/components/ReportMap.vue
@@ -85,7 +85,11 @@ onMounted(() => {
 </script>
 
 <template>
-  <div id="report-map" style="height: 400px"></div>
+  <p v-if="hucId" class="is-size-5 mb-2">
+    Outflow segments in the map below are
+    <strong style="color: #ff0000">red</strong>.
+  </p>
+  <div id="report-map" style="height: 400px" class="mb-6"></div>
 </template>
 
 <style lang="scss"></style>


### PR DESCRIPTION
This PR adds the following text above both the front-page map, and the report mini-map (but only when viewing a report page for a HUC-8).

> Outflow segments in the map below are red.

To test the HUC-8 mini-map text, remember you can enter something like "north" or "south" in the search bar to get a HUC-8 autocomplete result.