### PR TITLE
Disable Bulma dark mode

### DIFF
--- a/webapp/assets/styles/main.scss
+++ b/webapp/assets/styles/main.scss
@@ -1,5 +1,5 @@
 @use '~/node_modules/leaflet/dist/leaflet.css';
-@use '~/node_modules/bulma/bulma.scss';
+@use '~/node_modules/bulma/versions/bulma-no-dark-mode.scss';
 
 @import url('https://fonts.googleapis.com/css2?family=DM+Serif+Text&family=IBM+Plex+Mono:wght@300;400;500&family=Zalando+Sans:ital,wght@0,200..900;1,200..900&display=swap');
 


### PR DESCRIPTION
Closes #151.

This PR simply disables Bulma's dark mode by changing the Bulma SCSS file we use in the webapp.

To test, switch to "Dark" mode in macOS' "Appearance" settings. View the webapp and confirm that it is using light mode, not dark mode, and all other Bulma formatting still works as before.