### PR TITLE
Lock y-axis to same min/max range across all scenarios/eras for each chart type

### DIFF
--- a/webapp/components/ReportMap.vue
+++ b/webapp/components/ReportMap.vue
@@ -4,11 +4,10 @@ import { useStreamSegmentStore } from '~/stores/streamSegment'
 import { getHandleCoord } from '~/utils/map'
 const streamSegmentStore = useStreamSegmentStore()
 let { hucId } = storeToRefs(streamSegmentStore)
+let map: any = null
 
 const hucBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Ahuc8&outputFormat=application%2Fjson&srsName=EPSG:4326&cql_filter=huc8=`
 const segBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Aseg_h8_outlet_stats_simplified&outputFormat=application%2Fjson&srsName=EPSG:4326&cql_filter=`
-
-let map: any = null
 
 const addHuc = () => {
   let hucUrl = hucBaseUrl + hucId.value

--- a/webapp/components/Viz/Hydrograph.vue
+++ b/webapp/components/Viz/Hydrograph.vue
@@ -2,7 +2,12 @@
 import { toRaw } from 'vue'
 import lowess from '@stdlib/stats-lowess'
 import { doyToDateString } from '~/utils/general'
-import { getLayout, getConfig, initializeChart } from '~/utils/chart'
+import {
+  getLayout,
+  getConfig,
+  initializeChart,
+  getDataRange,
+} from '~/utils/chart'
 const { $Plotly, $_ } = useNuxtApp()
 import type { Data } from 'plotly.js'
 
@@ -275,9 +280,21 @@ const buildChart = hg => {
     ticktext: xTickLabels,
   }
 
+  // Min/max need to be logarithmic to work with Plotly.js log chart type.
+  let { yMin, yMax } = getDataRange(hg)
+
+  // Log of 0 is undefined.
+  if (yMin <= 0) {
+    yMin = 0.001
+  }
+
+  let yMinLog = Math.log10(yMin)
+  let yMaxLog = Math.log10(yMax)
+
   let yAxisConfig = {
     type: 'log',
-    autorange: true,
+    autorange: false,
+    range: [yMinLog, yMaxLog],
   }
 
   let legendConfig = {

--- a/webapp/components/Viz/MaxFlowDates.vue
+++ b/webapp/components/Viz/MaxFlowDates.vue
@@ -200,8 +200,8 @@ const buildChart = () => {
 
   let axisColor = 'rgba(0,0,0,0.08)'
 
-  let keysToExclude = ['date', 'min']
-  let { yMin, yMax } = getDataRange(props.streamMinMaxFlowDates, keysToExclude)
+  let keysToExclude = ['date']
+  let { yMin, yMax } = getDataRange(props.streamMaxFlowDates, keysToExclude)
 
   layout['polar'] = {
     angularaxis: {

--- a/webapp/components/Viz/MinMaxFlowDates.vue
+++ b/webapp/components/Viz/MinMaxFlowDates.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { watch, toRaw } from 'vue'
 import { doyToDateString } from '~/utils/general'
-import { getLayout, getConfig, initializeChart } from '~/utils/chart'
+import {
+  getLayout,
+  getConfig,
+  initializeChart,
+  getDataRange,
+} from '~/utils/chart'
 const { $Plotly, $_ } = useNuxtApp()
 import type { Data } from 'plotly.js'
 
@@ -203,6 +208,9 @@ const buildChart = () => {
 
   let axisColor = 'rgba(0,0,0,0.08)'
 
+  let keysToExclude = ['date']
+  let { yMin, yMax } = getDataRange(props.streamMinMaxFlowDates, keysToExclude)
+
   layout['polar'] = {
     angularaxis: {
       tickmode: 'array',
@@ -231,6 +239,7 @@ const buildChart = () => {
       tickmode: 'auto',
       nticks: 4,
       gridcolor: axisColor,
+      range: [yMin, yMax],
     },
     domain: firstPlotDomain,
   }

--- a/webapp/components/Viz/MinMaxFlowDates.vue
+++ b/webapp/components/Viz/MinMaxFlowDates.vue
@@ -208,7 +208,7 @@ const buildChart = () => {
 
   let axisColor = 'rgba(0,0,0,0.08)'
 
-  let keysToExclude = ['date']
+  let keysToExclude = ['date', 'min']
   let { yMin, yMax } = getDataRange(props.streamMinMaxFlowDates, keysToExclude)
 
   layout['polar'] = {

--- a/webapp/components/Viz/MonthlyFlow.vue
+++ b/webapp/components/Viz/MonthlyFlow.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { watch, toRaw } from 'vue'
-import { getLayout, getConfig, initializeChart } from '~/utils/chart'
+import {
+  getLayout,
+  getConfig,
+  initializeChart,
+  getDataRange,
+} from '~/utils/chart'
 const { $Plotly, $_ } = useNuxtApp()
 import type { Data } from 'plotly.js'
 
@@ -161,6 +166,13 @@ const buildChart = () => {
     dtick: 1,
   }
 
+  let { yMin, yMax } = getDataRange(props.streamMonthlyFlow)
+
+  let yAxisSettings = {
+    range: [yMin, yMax],
+    autorange: false,
+  }
+
   let legendConfig = {
     orientation: 'h',
     yanchor: 'top',
@@ -173,7 +185,7 @@ const buildChart = () => {
     titleText,
     'Mean monthly flow, cf/s',
     xAxisSettings,
-    {},
+    yAxisSettings,
     legendConfig
   )
 

--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -65,6 +65,36 @@ export const getLayout = (
   autosize: true,
 })
 
+// Recursively extract all relevant values (data keys not in excludeKeys) from
+// API data response, find the min/max values, add some padding, and return.
+export const getDataRange = (
+  data: any,
+  excludeKeys: string[] = []
+): { yMin: number; yMax: number } => {
+  const extractNumbers = (obj: any): number[] => {
+    if (typeof obj === 'number') {
+      return [obj]
+    }
+    if (Array.isArray(obj)) {
+      return obj.flatMap(extractNumbers)
+    }
+    if (obj && typeof obj === 'object') {
+      const allowedEntries = Object.entries(obj).filter(
+        ([key]) => !excludeKeys.includes(key)
+      )
+      return allowedEntries.flatMap(([, value]) => extractNumbers(value))
+    }
+    return []
+  }
+
+  const allValues = extractNumbers(data)
+  const paddingFactor = 0.05
+  return {
+    yMin: Math.min(...allValues) * (1 - paddingFactor),
+    yMax: Math.max(...allValues) * (1 + paddingFactor),
+  }
+}
+
 export const initializeChart = (
   $Plotly: any,
   chartId: string,


### PR DESCRIPTION
Closes #147.
Closes #153.

This PR implements a shared function in `chart.ts` that determines the min/max values for the data being plotted. Each chart type then uses these values to lock the y-axis to the same range across all scenarios and eras to make comparisons easier when the user switches between modes/eras.

To test, be sure to run the webapp against the `main` branch of the Data API:

```
cd data-api
git checkout main
git pull --ff-only
micromamba activate api-env
export FLASK_APP=application.py
flask run
```

```
cd hydroviz/webapp
git checkout lock_y_axis
nvm use lts/jod
export SNAP_API_URL=http://localhost:5000
npm run dev
```

Then start looking at the report page for various stream segments and switching between modes (middle-of-the-road vs. extremes) and eras) to confirm that the y-axis range always stays the same for each chart type.

Hydrographs for low-flow segments still look a bit strange due to the limitations of logarithmic charts. They may look slightly stranger than before because I'm changing yMin values of `0` to `0.001` instead to avoid undefined behavior of `Math.log10(0)`.