### PR TITLE
Small changes to reflect differences in API output and remove old references to min flow from max flow date polarscatter charts

### DIFF
--- a/webapp/components/Report.vue
+++ b/webapp/components/Report.vue
@@ -5,7 +5,7 @@ let {
   streamStats,
   streamHydrograph,
   streamMonthlyFlow,
-  streamMinMaxFlowDates,
+  streamMaxFlowDates,
   hucId,
   segmentId,
   segmentName,
@@ -122,9 +122,7 @@ onUnmounted(() => {
             maximum flow rates.
           </p>
         </div>
-        <VizMinMaxFlowDates
-          :stream-min-max-flow-dates="streamMinMaxFlowDates"
-        />
+        <VizMaxFlowDates :stream-max-flow-dates="streamMaxFlowDates" />
       </div>
     </section>
 

--- a/webapp/components/StatsTable.vue
+++ b/webapp/components/StatsTable.vue
@@ -57,7 +57,9 @@ const tableCaptionHtml = computed(() => {
               {{
                 fnc(
                   roundSigFig(
-                    Number(streamStats['projected'][appEra].mid[stat.id])
+                    Number(
+                      streamStats['projected'][appEra]['rcp60'][stat.id].median
+                    )
                   )
                 )
               }}
@@ -70,7 +72,9 @@ const tableCaptionHtml = computed(() => {
               "
               :future="
                 roundSigFig(
-                  Number(streamStats['projected'][appEra].mid[stat.id])
+                  Number(
+                    streamStats['projected'][appEra]['rcp60'][stat.id].median
+                  )
                 )
               "
             />
@@ -88,9 +92,8 @@ const tableCaptionHtml = computed(() => {
           <th scope="col" width="15%">
             Modeled Historical<br />(1976&ndash;2005)
           </th>
-
-          <th scope="col">Minimum, {{ scenarioFullNames['rcp45'] }}</th>
-          <th scope="col">Maximum, {{ scenarioFullNames['rcp85'] }}</th>
+          <th scope="col">Median, {{ scenarioFullNames['rcp45'] }}</th>
+          <th scope="col">Median, {{ scenarioFullNames['rcp85'] }}</th>
         </tr>
       </thead>
       <tbody>
@@ -114,7 +117,9 @@ const tableCaptionHtml = computed(() => {
               {{
                 fnc(
                   roundSigFig(
-                    Number(streamStats['projected'][appEra].min[stat.id])
+                    Number(
+                      streamStats['projected'][appEra]['rcp45'][stat.id].median
+                    )
                   )
                 )
               }}
@@ -127,7 +132,9 @@ const tableCaptionHtml = computed(() => {
               "
               :future="
                 roundSigFig(
-                  Number(streamStats['projected'][appEra].min[stat.id])
+                  Number(
+                    streamStats['projected'][appEra]['rcp45'][stat.id].median
+                  )
                 )
               "
             />
@@ -137,7 +144,9 @@ const tableCaptionHtml = computed(() => {
               {{
                 fnc(
                   roundSigFig(
-                    Number(streamStats['projected'][appEra].max[stat.id])
+                    Number(
+                      streamStats['projected'][appEra]['rcp85'][stat.id].median
+                    )
                   )
                 )
               }}
@@ -150,7 +159,9 @@ const tableCaptionHtml = computed(() => {
               "
               :future="
                 roundSigFig(
-                  Number(streamStats['projected'][appEra].max[stat.id])
+                  Number(
+                    streamStats['projected'][appEra]['rcp85'][stat.id].median
+                  )
                 )
               "
             />

--- a/webapp/components/StatsTable.vue
+++ b/webapp/components/StatsTable.vue
@@ -118,7 +118,7 @@ const tableCaptionHtml = computed(() => {
                 fnc(
                   roundSigFig(
                     Number(
-                      streamStats['projected'][appEra]['rcp45'][stat.id].median
+                      streamStats['projected'][appEra]['rcp45'][stat.id].min
                     )
                   )
                 )
@@ -132,9 +132,7 @@ const tableCaptionHtml = computed(() => {
               "
               :future="
                 roundSigFig(
-                  Number(
-                    streamStats['projected'][appEra]['rcp45'][stat.id].median
-                  )
+                  Number(streamStats['projected'][appEra]['rcp45'][stat.id].min)
                 )
               "
             />
@@ -145,7 +143,7 @@ const tableCaptionHtml = computed(() => {
                 fnc(
                   roundSigFig(
                     Number(
-                      streamStats['projected'][appEra]['rcp85'][stat.id].median
+                      streamStats['projected'][appEra]['rcp85'][stat.id].max
                     )
                   )
                 )
@@ -159,9 +157,7 @@ const tableCaptionHtml = computed(() => {
               "
               :future="
                 roundSigFig(
-                  Number(
-                    streamStats['projected'][appEra]['rcp85'][stat.id].median
-                  )
+                  Number(streamStats['projected'][appEra]['rcp85'][stat.id].max)
                 )
               "
             />

--- a/webapp/components/Viz/MaxFlowDates.vue
+++ b/webapp/components/Viz/MaxFlowDates.vue
@@ -9,23 +9,23 @@ import { useStreamSegmentStore } from '~/stores/streamSegment'
 const streamSegmentStore = useStreamSegmentStore()
 const { appContext, appEra } = storeToRefs(streamSegmentStore)
 
-const props = defineProps(['streamMinMaxFlowDates'])
+const props = defineProps(['streamMaxFlowDates'])
 
 onMounted(() => {
   initializeChart(
     $Plotly,
-    'min-max-flow-dates',
+    'max-flow-dates',
     buildChart,
-    toRaw(props.streamMinMaxFlowDates)
+    toRaw(props.streamMaxFlowDates)
   )
 })
 
 watch([appContext, appEra], () => {
   initializeChart(
     $Plotly,
-    'min-max-flow-dates',
+    'max-flow-dates',
     buildChart,
-    toRaw(props.streamMinMaxFlowDates)
+    toRaw(props.streamMaxFlowDates)
   )
 })
 
@@ -67,12 +67,8 @@ const buildChart = () => {
   }
 
   scenarios.forEach(scenario => {
-    let historicalFlow = [
-      props.streamMinMaxFlowDates['historical']['max']['flow'],
-    ]
-    let historicalFlowDate = [
-      props.streamMinMaxFlowDates['historical']['max']['date'],
-    ]
+    let historicalFlow = [props.streamMaxFlowDates['historical']['flow']]
+    let historicalFlowDate = [props.streamMaxFlowDates['historical']['date']]
 
     let customdataHistorical: string[][] = []
     historicalFlowDate.forEach((doy: number, index: number) => {
@@ -116,13 +112,9 @@ const buildChart = () => {
     historicalTraces.push(historicalTrace)
 
     let projectedFlows =
-      props.streamMinMaxFlowDates['projected'][appEra.value][scenario]['max'][
-        'flow'
-      ]
+      props.streamMaxFlowDates['projected'][appEra.value][scenario]['flow']
     let projectedDates = $_.cloneDeep(
-      props.streamMinMaxFlowDates['projected'][appEra.value][scenario]['max'][
-        'date'
-      ]
+      props.streamMaxFlowDates['projected'][appEra.value][scenario]['date']
     )
 
     let customdataProjected: string[][] = []
@@ -243,12 +235,12 @@ const buildChart = () => {
   layout['margin'] = { t: 100 }
   layout['height'] = 500
 
-  const config = getConfig('min-max-flow-dates')
+  const config = getConfig('max-flow-dates')
 
-  $Plotly.newPlot('min-max-flow-dates', traces, layout, config)
+  $Plotly.newPlot('max-flow-dates', traces, layout, config)
 }
 </script>
 
 <template>
-  <div id="min-max-flow-dates" class="mb-5"></div>
+  <div id="max-flow-dates" class="mb-5"></div>
 </template>

--- a/webapp/stores/streamSegment.ts
+++ b/webapp/stores/streamSegment.ts
@@ -12,7 +12,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
   const streamSummary = shallowRef(null)
   const streamHydrograph = shallowRef(null)
   const streamMonthlyFlow = shallowRef(null)
-  const streamMinMaxFlowDates = shallowRef(null)
+  const streamMaxFlowDates = shallowRef(null)
   const streamStats = shallowRef(null)
   const appContext = ref<AppContext>('mid')
   const appEra = ref<Era>('2046-2075')
@@ -65,7 +65,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamSummary.value = null
     streamHydrograph.value = null
     streamMonthlyFlow.value = null
-    streamMinMaxFlowDates.value = null
+    streamMaxFlowDates.value = null
     streamStats.value = null
     var dataResponse
 
@@ -118,7 +118,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
       streamSummary.value = dataResponse['summary']
       streamHydrograph.value = dataResponse['hydrograph']
       streamMonthlyFlow.value = dataResponse['monthly_flow']
-      streamMinMaxFlowDates.value = dataResponse['min_max_flow_dates']
+      streamMaxFlowDates.value = dataResponse['max_flow_dates']
       streamStats.value = dataResponse['stats']
     } catch {
       console.error('API response does not contain expected data.')
@@ -131,7 +131,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamSummary.value = null
     streamHydrograph.value = null
     streamMonthlyFlow.value = null
-    streamMinMaxFlowDates.value = null
+    streamMaxFlowDates.value = null
     streamStats.value = null
     hucId.value = null
   }
@@ -142,7 +142,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamSummary,
     streamHydrograph,
     streamMonthlyFlow,
-    streamMinMaxFlowDates,
+    streamMaxFlowDates,
     streamStats,
     fetchStreamStats,
     fetchHucStats,


### PR DESCRIPTION
This PR makes a couple small changes to the webapp to work with the latest Data API changes in https://github.com/ua-snap/data-api/pull/715, including:

- Remove min flow references from `MinMaxFlowDates.vue` and rename it to `MaxFlowDates.vue`. We had previously experimented with showing min and max flow dates on the same polarscatter charts, and it didn't work out because all min flow markers were clustered/overlapping over the center and not meaningful.
- Updates the `StatsTable.vue` to reference specific scenarios. Previously, the "extremes" mode of the stats tables were showing the min/max values across all scenarios (including `rcp60`) and the column headers were inaccurate. This fixes the data so the column headers and table intro text ("median") are accurate.

To test (assuming https://github.com/ua-snap/data-api/pull/715 hasn't been merged yet):

```
cd data-api
git checkout hydroviz_webapp_endpoint
git pull --ff-only
micromamba activate api-env
export FLASK_APP=application.py
flask run
```

```
cd hydroviz/webapp
git checkout reflect_api_changes
nvm use lts/jod
export SNAP_API_URL=http://localhost:5000
npm run dev
```

Then look at the max flow date charts and stats tables for a few different streams, eras, and for middle-of-the-road vs. extremes modes.