### PR TITLE
Removes the ability to drag a select a region on the charts.

### DIFF
--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -63,6 +63,7 @@ export const getLayout = (
     pad: 20,
   },
   autosize: true,
+  dragmode: false,
 })
 
 export const initializeChart = (


### PR DESCRIPTION
This is a very simple PR that removes the Plotly charts' ability to zoom into a region by dragging your mouse icon across a section of the chart. 

Closes #113 