### PR TITLE
Show all stream segments when part of a HUC8

### DIFF
--- a/webapp/components/ReportMap.vue
+++ b/webapp/components/ReportMap.vue
@@ -97,10 +97,10 @@ const addSegment = () => {
       if (!data.features || data.features.length === 0) {
         return
       }
-      const isHUC8 = data.features[0].properties.huc8
+      const HUC8 = data.features[0].properties.huc8
 
-      if (isHUC8) {
-        let allSegmentsUrl = segBaseUrl + `huc8=${isHUC8}`
+      if (HUC8) {
+        let allSegmentsUrl = segBaseUrl + `huc8=${HUC8}`
         fetch(allSegmentsUrl)
           .then(response => response.json())
           .then(allData => {

--- a/webapp/components/ReportMap.vue
+++ b/webapp/components/ReportMap.vue
@@ -95,16 +95,49 @@ const addSegment = () => {
   fetch(url)
     .then(response => response.json())
     .then(data => {
-      let geoJsonLayer = $L
-        .geoJSON(data, {
-          style: {
-            color: '#0000ff',
-            weight: 3,
-          },
-          interactive: false,
-        })
-        .addTo(map)
-      map.fitBounds(geoJsonLayer.getBounds())
+      const isHUC8 = data.features[0].properties.huc8
+
+      if (isHUC8) {
+        let allSegmentsUrl = segBaseUrl + `huc8=${isHUC8}`
+        fetch(allSegmentsUrl)
+          .then(response => response.json())
+          .then(allData => {
+            allData.features.forEach(feature => {
+              const isOutlet = feature.properties.h8_outlet === 1
+              const isSelected =
+                feature.properties.seg_id_nat === segmentId.value
+
+              const currentStream = $L
+                .geoJSON(feature, {
+                  style: {
+                    color: isOutlet ? '#ff0000' : '#0000ff',
+                    weight: isSelected ? 5 : 2,
+                    opacity: 1,
+                    interactive: false,
+                  },
+                })
+                .addTo(map)
+
+              if (isSelected) {
+                map.fitBounds(currentStream.getBounds())
+              }
+            })
+          })
+          .catch(error => {
+            console.error('Error fetching all stream segments:', error)
+          })
+      } else {
+        const selectedStream = $L
+          .geoJSON(data, {
+            style: {
+              weight: 5,
+              color: '#0000ff',
+              interactive: false,
+            },
+          })
+          .addTo(map)
+        map.fitBounds(selectedStream.getBounds())
+      }
     })
     .catch(error => {
       console.error('Error fetching GeoJSON data:', error)
@@ -117,6 +150,7 @@ const initializeMap = () => {
       scrollWheelZoom: false,
       dragging: false,
       zoomControl: false,
+      doubleClickZoom: false,
       zoomSnap: 0.1,
     })
     .setView([37.8, -96], 8)

--- a/webapp/components/ReportMap.vue
+++ b/webapp/components/ReportMap.vue
@@ -11,13 +11,6 @@ const segBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&ver
 let map: any = null
 let mapLayers: any[] = []
 
-const clearMapLayers = () => {
-  mapLayers.forEach(layer => {
-    map.removeLayer(layer)
-  })
-  mapLayers = []
-}
-
 const addHuc = () => {
   let hucUrl = hucBaseUrl + hucId.value
   fetch(hucUrl)
@@ -97,7 +90,6 @@ const addHuc = () => {
 }
 
 const addSegment = () => {
-  clearMapLayers()
   let url = segBaseUrl + `seg_id_nat=${segmentId.value}`
   fetch(url)
     .then(response => response.json())

--- a/webapp/components/ReportMap.vue
+++ b/webapp/components/ReportMap.vue
@@ -94,6 +94,9 @@ const addSegment = () => {
   fetch(url)
     .then(response => response.json())
     .then(data => {
+      if (!data.features || data.features.length === 0) {
+        return
+      }
       const isHUC8 = data.features[0].properties.huc8
 
       if (isHUC8) {

--- a/webapp/components/ReportMap.vue
+++ b/webapp/components/ReportMap.vue
@@ -3,12 +3,20 @@ const { $L, $config } = useNuxtApp()
 import { useStreamSegmentStore } from '~/stores/streamSegment'
 import { getHandleCoord } from '~/utils/map'
 const streamSegmentStore = useStreamSegmentStore()
-let { hucId } = storeToRefs(streamSegmentStore)
+let { hucId, segmentId } = storeToRefs(streamSegmentStore)
 
 const hucBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Ahuc8&outputFormat=application%2Fjson&srsName=EPSG:4326&cql_filter=huc8=`
 const segBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Aseg_h8_outlet_stats_simplified&outputFormat=application%2Fjson&srsName=EPSG:4326&cql_filter=`
 
 let map: any = null
+let mapLayers: any[] = []
+
+const clearMapLayers = () => {
+  mapLayers.forEach(layer => {
+    map.removeLayer(layer)
+  })
+  mapLayers = []
+}
 
 const addHuc = () => {
   let hucUrl = hucBaseUrl + hucId.value
@@ -89,8 +97,7 @@ const addHuc = () => {
 }
 
 const addSegment = () => {
-  const streamSegmentStore = useStreamSegmentStore()
-  const { segmentId } = storeToRefs(streamSegmentStore)
+  clearMapLayers()
   let url = segBaseUrl + `seg_id_nat=${segmentId.value}`
   fetch(url)
     .then(response => response.json())
@@ -113,7 +120,22 @@ const addSegment = () => {
                     color: isOutlet ? '#ff0000' : '#0000ff',
                     weight: isSelected ? 5 : 2,
                     opacity: 1,
-                    interactive: false,
+                    interactive: !isSelected,
+                  },
+                  onEachFeature: (feature, layer) => {
+                    if (!isSelected) {
+                      layer.on('click', () => {
+                        navigateTo(`/conus/${feature.properties.seg_id_nat}`, {
+                          external: true,
+                        })
+                      })
+                      layer.on('mouseover', () => {
+                        layer.setStyle({ weight: 5 })
+                      })
+                      layer.on('mouseout', () => {
+                        layer.setStyle({ weight: 2 })
+                      })
+                    }
                   },
                 })
                 .addTo(map)


### PR DESCRIPTION
This PR adds the other stream segments of a HUC8 onto the report map when a particular stream is chosen. The selected stream is a wider line to indicate that it is the one that has been selected. When mousing over the non-selected streams, the width of that stream's line increases and a pointer mouse icon is seen to indicate you can click on the stream segment. By clicking on the stream segment, you can jump to another report for that stream segment.

This PR also removes the ability to double click zoom into the report map.

Closes #142 