### PR TITLE
Updates for WAVE errors for WCAG accessibility

### DIFF
--- a/webapp/components/Search.vue
+++ b/webapp/components/Search.vue
@@ -91,7 +91,9 @@ onMounted(() => {
   <section class="section">
     <div class="container">
       <div class="field">
-        <label class="label">Search by stream segment name or HUC-8 ID</label>
+        <label class="label" for="search"
+          >Search by stream segment name or HUC-8 ID</label
+        >
         <input id="search" v-model="inputValue" class="input" />
       </div>
     </div>

--- a/webapp/nuxt.config.ts
+++ b/webapp/nuxt.config.ts
@@ -4,6 +4,13 @@ export default defineNuxtConfig({
   css: ['assets/styles/main.scss'],
   pages: true,
   modules: ['@pinia/nuxt'],
+  app: {
+    head: {
+      htmlAttrs: {
+        lang: 'en',
+      },
+    },
+  },
   runtimeConfig: {
     public: {
       snapApiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',


### PR DESCRIPTION
This PR is a very simplistic one as the web page is mostly good, including the report section, in regards to WCAG accessibility requirements. The only things that were highlighted were that the page didn't have a default language and the form control didn't have a label directly associated with it. Both of these are fixed with this change.

There is a third error that expects there to be a title for the website above the navigation bar, but I ignored that error for this because the title is directly below the tabs and seems very clear to me.

Closes #84 