### PR TITLE
Detect and handle null values in StatsTable, display "N/A"

### DIFF
--- a/webapp/components/StatValue.vue
+++ b/webapp/components/StatValue.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { fnc, roundSigFig } from '~/utils/general'
+
+const props = defineProps<{
+  value: string | null
+  past?: string | null
+}>()
+
+let value: number | null = null
+if (props.value !== null && props.value !== undefined) {
+  value = roundSigFig(Number(props.value))
+}
+
+let past: number | null = null
+if (props.past !== null && props.past !== undefined) {
+  past = roundSigFig(Number(props.past))
+}
+
+let formattedValue: string
+if (props.value === null || props.value === undefined) {
+  formattedValue = 'N/A'
+} else {
+  formattedValue = fnc(value!)
+}
+</script>
+
+<template>
+  <span>
+    <span class="number">{{ formattedValue }}</span>
+    <Diff v-if="past !== null && value !== null" :past="past" :future="value" />
+  </span>
+</template>

--- a/webapp/components/StatsTable.vue
+++ b/webapp/components/StatsTable.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { eraFullNamesHtml, scenarioFullNames } from '~/types/modelsScenarios'
-import { fnc, roundSigFig } from '~/utils/general'
 import { computed } from 'vue'
 
 import { streamflowStatistics } from '~/types/statsVars'
@@ -44,38 +43,16 @@ const tableCaptionHtml = computed(() => {
           <td v-html="stat.description"></td>
           <td v-html="stat.units_short"></td>
           <td>
-            <span class="number">{{
-              fnc(
-                roundSigFig(
-                  Number(streamStats['historical']['1976-2005'][stat.id])
-                )
-              )
-            }}</span>
+            <StatValue
+              :value="streamStats['historical']['1976-2005'][stat.id]"
+            />
           </td>
           <td>
-            <span class="number">
-              {{
-                fnc(
-                  roundSigFig(
-                    Number(
-                      streamStats['projected'][appEra]['rcp60'][stat.id].median
-                    )
-                  )
-                )
-              }}
-            </span>
-            <Diff
-              :past="
-                roundSigFig(
-                  Number(streamStats['historical']['1976-2005'][stat.id])
-                )
-              "
+            <StatValue
+              :value="streamStats['projected'][appEra]['rcp60'][stat.id].median"
+              :past="streamStats['historical']['1976-2005'][stat.id]"
               :future="
-                roundSigFig(
-                  Number(
-                    streamStats['projected'][appEra]['rcp60'][stat.id].median
-                  )
-                )
+                streamStats['projected'][appEra]['rcp60'][stat.id].median
               "
             />
           </td>
@@ -104,62 +81,20 @@ const tableCaptionHtml = computed(() => {
           <td v-html="stat.description"></td>
           <td v-html="stat.units_short"></td>
           <td>
-            <span class="number">{{
-              fnc(
-                roundSigFig(
-                  Number(streamStats['historical']['1976-2005'][stat.id])
-                )
-              )
-            }}</span>
-          </td>
-          <td>
-            <span class="number">
-              {{
-                fnc(
-                  roundSigFig(
-                    Number(
-                      streamStats['projected'][appEra]['rcp45'][stat.id].min
-                    )
-                  )
-                )
-              }}
-            </span>
-            <Diff
-              :past="
-                roundSigFig(
-                  Number(streamStats['historical']['1976-2005'][stat.id])
-                )
-              "
-              :future="
-                roundSigFig(
-                  Number(streamStats['projected'][appEra]['rcp45'][stat.id].min)
-                )
-              "
+            <StatValue
+              :value="streamStats['historical']['1976-2005'][stat.id]"
             />
           </td>
           <td>
-            <span class="number">
-              {{
-                fnc(
-                  roundSigFig(
-                    Number(
-                      streamStats['projected'][appEra]['rcp85'][stat.id].max
-                    )
-                  )
-                )
-              }}
-            </span>
-            <Diff
-              :past="
-                roundSigFig(
-                  Number(streamStats['historical']['1976-2005'][stat.id])
-                )
-              "
-              :future="
-                roundSigFig(
-                  Number(streamStats['projected'][appEra]['rcp85'][stat.id].max)
-                )
-              "
+            <StatValue
+              :value="streamStats['projected'][appEra]['rcp45'][stat.id].min"
+              :past="streamStats['historical']['1976-2005'][stat.id]"
+            />
+          </td>
+          <td>
+            <StatValue
+              :value="streamStats['projected'][appEra]['rcp85'][stat.id].max"
+              :past="streamStats['historical']['1976-2005'][stat.id]"
             />
           </td>
         </tr>

--- a/webapp/components/StatsTable.vue
+++ b/webapp/components/StatsTable.vue
@@ -51,9 +51,6 @@ const tableCaptionHtml = computed(() => {
             <StatValue
               :value="streamStats['projected'][appEra]['rcp60'][stat.id].median"
               :past="streamStats['historical']['1976-2005'][stat.id]"
-              :future="
-                streamStats['projected'][appEra]['rcp60'][stat.id].median
-              "
             />
           </td>
         </tr>


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/189.

This PR detects `null` values in the Data API output for the stats table and shows them as "N/A" instead of `0`, and doesn't attempt to do difference math on them.

To test, run the webapp against the `main` branch of the Data API and visit the following report page, for example:

http://localhost:3000/conus/13369

Observe that the `lf1` variable shows "N/A" for the projected values. The historical value is still `0` because the historical Maurer dataset value is in fact 0. Only the projected values are `null`.