### PR TITLE
Fix broken Leaflet marker image when webapp is built

### DIFF
--- a/webapp/plugins/leaflet.client.ts
+++ b/webapp/plugins/leaflet.client.ts
@@ -1,4 +1,14 @@
 import L from 'leaflet'
+import markerIcon2xUrl from 'leaflet/dist/images/marker-icon-2x.png'
+import markerIconUrl from 'leaflet/dist/images/marker-icon.png'
+import markerShadowUrl from 'leaflet/dist/images/marker-shadow.png'
+
+delete (L.Icon.Default.prototype as any)._getIconUrl
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: markerIcon2xUrl,
+  iconUrl: markerIconUrl,
+  shadowUrl: markerShadowUrl,
+})
 
 export default defineNuxtPlugin(nuxtApp => {
   return {


### PR DESCRIPTION
Closes #166.

This PR fixes the broken Leaflet marker image when the webapp is built (and deployed to S3). To test:

```
npm run generate
cd .output/public
python -m http.server
```

Visit the built webapp at http://[::]:8000/

Load a report page for a stream segment and observe that the Leaflet marker works 🎉 