### PR TITLE
Catch additional type to avoid console warnings

### DIFF
--- a/webapp/components/StatValue.vue
+++ b/webapp/components/StatValue.vue
@@ -3,8 +3,8 @@ import { fnc, roundSigFig } from '~/utils/general'
 import { computed } from 'vue'
 
 const props = defineProps<{
-  value: string | null
-  past?: string | null
+  value: string | number | null
+  past?: string | number | null
   statId?: string | undefined
 }>()
 


### PR DESCRIPTION
Tiny change to handle the case where values coming into `StatValue` are proper number types.

Testing:
 - On main, load a stream segment and note that the console gets a bunch of warnings.
 - On this branch, those warnings are gone.

Are there issues with taking this approach?