### PR TITLE
Clear segmentRegion in clearStats() to fix Alaska GeoJSON segments failing to load sometimes

### DIFF
--- a/webapp/stores/streamSegment.ts
+++ b/webapp/stores/streamSegment.ts
@@ -155,6 +155,7 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
 
   const clearStats = (): void => {
     segmentId.value = null
+    segmentRegion.value = null
     segmentName.value = null
     streamSummary.value = null
     streamHydrograph.value = null


### PR DESCRIPTION
This PR fixes a bug that both @brucecrevensten and I noticed after Alaska was incorporated into the webapp.

To replicate the bug, from the `main` branch:

1. Use the CONUS map to click a HUC, zoom in, select a stream segment, and load the report page.
1. Click "Home" in the navbar to go back.
1. Use the Alaska map to click a HUC, zoom in, and notice that the interactive GeoJSON stream segments fail to load.

Observe that the issue goes away if you repeat the above steps from the `alaska_segments_bugfix` branch.

This was happening because the `segmentRegion` variable was not getting cleared like the other variables when the user navigates away from the report page, and the front page Alaska map was attempting to load GeoJSON segments using the CONUS GeoServer URL.