### PR TITLE
Fix report map stream navigation fail-to-load bug

### DIFF
--- a/webapp/components/Map.vue
+++ b/webapp/components/Map.vue
@@ -569,6 +569,9 @@ const loadSimplifiedHucs = async () => {
 
 onMounted(() => {
   Promise.all([loadSimplifiedHucs(), loadPerimeter()]).then(() => {
+    let streamSegmentStore = useStreamSegmentStore()
+    let { segmentRegion } = storeToRefs(streamSegmentStore)
+    segmentRegion.value = null
     initializeMap()
     // Apply whatever phase the URL describes (default Phase 0), then ensure the
     // URL reflects it. Both are replaces, so a fresh load adds no history depth.

--- a/webapp/stores/streamSegment.ts
+++ b/webapp/stores/streamSegment.ts
@@ -102,7 +102,6 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
   // Full reset of app data and loading state
   const clearStats = (): void => {
     segmentId.value = null
-    segmentRegion.value = null
     segmentUsgsGaugeId.value = null
     segmentHuc8Id.value = null
     segmentIsHuc8Outlet.value = null
@@ -113,7 +112,6 @@ export const useStreamSegmentStore = defineStore('streamSegmentStore', () => {
     streamMonthlyFlow.value = null
     streamMaxFlowDates.value = null
     streamStats.value = null
-    isLoading.value = false
     apiSlow.value = false
     apiFailed.value = false
   }

--- a/webapp/utils/map.ts
+++ b/webapp/utils/map.ts
@@ -213,7 +213,6 @@ export const addSegmentsGeoJson = ({
         isLoading.value = true
         const routePrefix =
           region === 'alaska' ? '/alaska/stream' : '/conus/stream'
-        segmentRegion.value = null
         const segId = feature.properties[idProperty]
         navigateTo(routePrefix + '/' + segId)
       })


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/230.

This PR fixes the bug described in #230 (report page fails to load if you click a subsequent stream segment from the report map) by making a few tweaks to when the `segmentRegion` and `isLoading` variables are cleared. There were actually two separate bugs happening at the same time:

- Clearing `isLoading` in `clearStats()` caused the loading bar not to show when clicking a new stream segment, but it was still attempting to fetch data (and errored out in the console after ~10 seconds).
- Clearing `segmentRegion` caused the webapp to lose track of the region context, causing it to attempt to load Alaska stream segments and data from the wrong WFS / Data API URLs.

To test:

- From the front page, choose a CONUS stream segment, load the report page, click another CONUS stream segment from the report page map.
- Click the back button to return to the front page to make sure it remembers the position & zoom on the front page CONUS map.
- Repeat the same thing for Alaska. Basically just go back and forth between CONUS and Alaska to make sure everything's working as intended.