### PR TITLE
Add Back buttons to maps and report page (#226)

### DIFF
--- a/webapp/components/Map.vue
+++ b/webapp/components/Map.vue
@@ -613,7 +613,7 @@ onMounted(() => {
     <button
       v-if="currentPhase > MapPhase.Overview"
       type="button"
-      class="button map-back-button"
+      class="button is-size-5 has-text-weight-semibold map-back-button has-shadow-5"
       @click="goBackPhase"
     >
       &larr;&nbsp;{{ backButtonLabel }}
@@ -643,8 +643,6 @@ onMounted(() => {
   left: 0.75rem;
   // Above Leaflet panes (max ~700), below the loading overlay (1100).
   z-index: 1000;
-  font-weight: 600;
-  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.4);
 }
 
 .map-loading-overlay {

--- a/webapp/components/Map.vue
+++ b/webapp/components/Map.vue
@@ -114,8 +114,9 @@ let detailedHucLayer: any
 let perimeter: any
 let simplifiedHucs: any
 
-// The phase the map is currently displaying. Set only by the enterPhaseN functions.
-let currentPhase: MapPhase = MapPhase.Overview
+// The phase the map is currently displaying. Set only by the enterPhaseN
+// functions. A ref so the template can show/hide the Back button reactively.
+const currentPhase = ref<MapPhase>(MapPhase.Overview)
 // Guards against redundant re-application of the same phase state.
 let lastAppliedKey = ''
 // Set while the Phase 2 swap moves the map itself, so the moveend handler does
@@ -145,7 +146,7 @@ const hideLayer = (layer: any) => {
 // Layers: HUC choropleth (hucWmsLayer) + a transparent perimeter overlay whose
 // clicks advance the map to Phase 1.
 const enterPhase0 = () => {
-  currentPhase = MapPhase.Overview
+  currentPhase.value = MapPhase.Overview
   isLoadingPhase2.value = false
   hideLayer(detailedHucLayer)
   clearSegmentLayers(map)
@@ -160,7 +161,7 @@ const enterPhase0 = () => {
 // Layers: HUC-8 choropleth (hucWmsLayer) + invisible simplifiedHucsLayer (hover/click targets)
 // + segWmsLayer stream overlay. The perimeter is hidden.
 const enterPhase1 = (center: [number, number]) => {
-  currentPhase = MapPhase.WmsHuc
+  currentPhase.value = MapPhase.WmsHuc
   isLoadingPhase2.value = false
   hideLayer(detailedHucLayer)
   clearSegmentLayers(map)
@@ -179,7 +180,7 @@ const enterPhase1 = (center: [number, number]) => {
 // layers hidden. The Phase 1 view is left fully intact while the data loads;
 // loadPhase2Data swaps everything in atomically once it's ready.
 const enterPhase2 = (hucId: string) => {
-  currentPhase = MapPhase.HucSelected
+  currentPhase.value = MapPhase.HucSelected
   isLoadingPhase2.value = true
   loadPhase2Data(hucId)
 }
@@ -318,16 +319,16 @@ const updatePositionInUrl = () => {
   const c = map.getCenter()
   const query: Record<string, string> = {
     ...safeQuery(),
-    [paramKeys.phase]: String(currentPhase),
+    [paramKeys.phase]: String(currentPhase.value),
   }
-  if (currentPhase >= MapPhase.WmsHuc) {
+  if (currentPhase.value >= MapPhase.WmsHuc) {
     query[paramKeys.lat] = c.lat.toFixed(5)
     query[paramKeys.lng] = c.lng.toFixed(5)
   } else {
     delete query[paramKeys.lat]
     delete query[paramKeys.lng]
   }
-  if (currentPhase < MapPhase.HucSelected) delete query[paramKeys.huc]
+  if (currentPhase.value < MapPhase.HucSelected) delete query[paramKeys.huc]
   router.replace({ query })
 }
 
@@ -339,9 +340,34 @@ watch(
   () => syncMapFromUrl()
 )
 
+// On-map Back button, shown in Phases 1 and 2 for people who don't reach for
+// the browser's Back button. Pushes the previous phase's URL state rather than
+// calling history.back(), so it works even when the current phase was entered
+// directly (shared link, search result) with no in-app history behind it.
+const goBackPhase = () => {
+  const query = { ...safeQuery() }
+  delete query[paramKeys.huc]
+  if (currentPhase.value === MapPhase.HucSelected) {
+    // Phase 2 -> Phase 1, keeping the current center so the view stays put.
+    query[paramKeys.phase] = String(MapPhase.WmsHuc)
+  } else {
+    // Phase 1 -> Phase 0, back to the default overview extent.
+    query[paramKeys.phase] = String(MapPhase.Overview)
+    delete query[paramKeys.lat]
+    delete query[paramKeys.lng]
+  }
+  router.push({ query })
+}
+
+const backButtonLabel = computed(() =>
+  currentPhase.value === MapPhase.HucSelected
+    ? 'Back to watersheds'
+    : 'Back to full map'
+)
+
 const hucFeatureHandler = (feature: any, layer: any) => {
   layer.on('mouseover', function (e: any) {
-    if (currentPhase !== MapPhase.WmsHuc) return
+    if (currentPhase.value !== MapPhase.WmsHuc) return
     e.target.setStyle({
       color: '#ffff00',
       fillColor: '#ffff00',
@@ -361,7 +387,7 @@ const hucFeatureHandler = (feature: any, layer: any) => {
     }
   })
   layer.on('mouseout', function (e: any) {
-    if (currentPhase !== MapPhase.WmsHuc) return
+    if (currentPhase.value !== MapPhase.WmsHuc) return
     e.target.setStyle({
       color: 'transparent',
       fillColor: 'transparent',
@@ -369,7 +395,7 @@ const hucFeatureHandler = (feature: any, layer: any) => {
     })
   })
   layer.on('click', function () {
-    if (currentPhase !== MapPhase.WmsHuc) return
+    if (currentPhase.value !== MapPhase.WmsHuc) return
     const hucId =
       region === 'alaska' ? feature.properties.ID_2 : feature.properties.huc8
     if (!hucId) return
@@ -525,7 +551,7 @@ const initializeMap = () => {
       return
     }
     // Refresh segments for the new viewport when panning within Phase 2.
-    if (currentPhase === MapPhase.HucSelected) {
+    if (currentPhase.value === MapPhase.HucSelected) {
       fetchAndAddSegmentsByBounds({
         map,
         $L,
@@ -584,6 +610,14 @@ onMounted(() => {
 <template>
   <div class="map-wrapper" style="height: 80vh; min-height: 500px">
     <div :id="config.mapId" style="height: 100%"></div>
+    <button
+      v-if="currentPhase > MapPhase.Overview"
+      type="button"
+      class="button map-back-button"
+      @click="goBackPhase"
+    >
+      &larr;&nbsp;{{ backButtonLabel }}
+    </button>
     <div v-if="isLoadingPhase2" class="map-loading-overlay">
       <img :src="waterLoaderUrl" class="map-loading-icon" alt="" />
       <p class="mt-3 has-text-white is-size-3 is-bold">
@@ -601,6 +635,16 @@ onMounted(() => {
 
 .map-wrapper {
   position: relative;
+}
+
+.map-back-button {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  // Above Leaflet panes (max ~700), below the loading overlay (1100).
+  z-index: 1000;
+  font-weight: 600;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.4);
 }
 
 .map-loading-overlay {

--- a/webapp/components/Report.vue
+++ b/webapp/components/Report.vue
@@ -17,6 +17,19 @@ let {
 } = storeToRefs(streamSegmentStore)
 import { scenarioFullNames } from '~/types/modelsScenarios'
 
+const router = useRouter()
+
+// Returns to the map, restoring its zoom/center/phase via browser history when
+// this report was reached from the map. On a direct visit (shared link) there
+// is no in-app history to go back to, so fall back to the home page.
+const goBackToMap = () => {
+  if (window.history.state?.back) {
+    router.back()
+  } else {
+    navigateTo('/')
+  }
+}
+
 onMounted(() => {
   streamSegmentStore.fetchStreamStats()
 })
@@ -27,6 +40,13 @@ onUnmounted(() => {
 </script>
 
 <template>
+  <section class="section pb-0">
+    <div class="container">
+      <a class="content is-size-5" href="/" @click.prevent="goBackToMap"
+        >&larr; Go back, choose another segment</a
+      >
+    </div>
+  </section>
   <Loading />
   <div v-if="streamStats">
     <section class="section">


### PR DESCRIPTION
Adds in-map navigation to go back (forward doesn't make as much sense).  Testing: for both maps, ensure the button feels visible and works properly to go back; also test pasting in links in fresh tabs which are already zoomed/etc to see if the navigation functions as expected.

[AI generated summary below]
>Adds an on-map Back button shown in Phases 1 and 2, for people who don't reach for the browser's Back button. The button steps the map back one phase by pushing the previous phase's URL state (rather than history.back()), so it also works when the phase was entered directly via a shared link or search result. Going Phase 2 -> Phase 1 keeps the current center so the view stays put.

>Also restores the "Go back, choose another segment" link at the top of the segment report page. It goes back through browser history when the report was reached from the map (restoring the exact map view), and falls back to the home page on a direct visit.

Closes #226