### PR TITLE
Add Umami tracking code and custom events

### DIFF
--- a/webapp/components/CsvDownload.vue
+++ b/webapp/components/CsvDownload.vue
@@ -9,6 +9,14 @@ const hydrologyPath = computed(() => {
     ? '/arctic_hydrology'
     : '/conus_hydrology'
 })
+
+const trackCsvDownload = (type: 'stats' | 'climatology') => {
+  window.trackUmamiEvent('csv-download', {
+    type,
+    segment: String(segmentId.value),
+    region: segmentRegion.value ?? undefined,
+  })
+}
 </script>
 
 <template>
@@ -22,6 +30,7 @@ const hydrologyPath = computed(() => {
         segmentId +
         '?format=csv'
       "
+      @click="trackCsvDownload('stats')"
       >complete modeled hydrologic statistics</a
     >
     or
@@ -33,6 +42,7 @@ const hydrologyPath = computed(() => {
         segmentId +
         '?format=csv'
       "
+      @click="trackCsvDownload('climatology')"
       >modeled daily streamflow climatologies</a
     >
     in CSV format for analysis in a spreadsheet.</span

--- a/webapp/components/GetAndUse.vue
+++ b/webapp/components/GetAndUse.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useStreamSegmentStore } from '~/stores/streamSegment'
 const streamSegmentStore = useStreamSegmentStore()
-let { segmentRegion } = storeToRefs(streamSegmentStore)
+let { segmentId, segmentRegion } = storeToRefs(streamSegmentStore)
 
 const { $config } = useNuxtApp()
 
@@ -12,17 +12,56 @@ const hydrologyPath = computed(() =>
 const hydrologyUrl = computed(
   () => `${$config.public.snapApiUrl}${hydrologyPath.value}`
 )
+
+const trackApiClick = () => {
+  window.trackUmamiEvent('api-link-click', {
+    segment: String(segmentId.value),
+    region: segmentRegion.value ?? undefined,
+  })
+}
+
+// Track when the user has scrolled far enough to bring this section (the last
+// one on the report page) into view. Fires at most once per report.
+const sectionEl = ref<HTMLElement | null>(null)
+let observer: IntersectionObserver | null = null
+
+onMounted(() => {
+  if (!sectionEl.value || !('IntersectionObserver' in window)) return
+  observer = new IntersectionObserver(
+    entries => {
+      if (entries.some(entry => entry.isIntersecting)) {
+        window.trackUmamiEvent('get-and-use-reached', {
+          segment: String(segmentId.value),
+          region: segmentRegion.value ?? undefined,
+        })
+        observer?.disconnect()
+        observer = null
+      }
+    },
+    // A tall section may never reach high visibility ratios, so fire once a
+    // small fraction of it is on screen.
+    { threshold: 0.1 }
+  )
+  observer.observe(sectionEl.value)
+})
+
+onUnmounted(() => {
+  observer?.disconnect()
+  observer = null
+})
 </script>
 
 <template>
-  <section class="section" id="get-and-use">
+  <section class="section" id="get-and-use" ref="sectionEl">
     <div class="container">
       <div class="content is-size-5">
         <h3 class="title is-3">Get &amp; use this data</h3>
         <ul>
           <li><CsvDownload /></li>
           <li>
-            <a :href="hydrologyUrl">Access this data programmatically</a>
+            <a :href="hydrologyUrl" @click="trackApiClick"
+              >Access this data programmatically</a
+            >
             with downloads ready for R and Python analysis.
           </li>
           <li v-if="segmentRegion == 'conus'">

--- a/webapp/components/Map.vue
+++ b/webapp/components/Map.vue
@@ -373,6 +373,12 @@ const hucFeatureHandler = (feature: any, layer: any) => {
     const hucId =
       region === 'alaska' ? feature.properties.ID_2 : feature.properties.huc8
     if (!hucId) return
+    window.trackUmamiEvent('huc-click', {
+      id: String(hucId),
+      name:
+        region === 'alaska' ? feature.properties.Name : feature.properties.name,
+      region,
+    })
     // Phase 1 -> Phase 2: push a new history entry for the selected HUC. Clear
     // the carried-over Phase 1 center so loadPhase2Data centers on the HUC; the
     // map's own moveend then records the Phase 2 center for later restoration.

--- a/webapp/components/NavBar.vue
+++ b/webapp/components/NavBar.vue
@@ -1,5 +1,9 @@
 <script setup>
 import { NuxtLink } from '#components'
+
+const trackNavClick = route => {
+  window.trackUmamiEvent('nav-click', { route })
+}
 </script>
 
 <template>
@@ -11,13 +15,33 @@ import { NuxtLink } from '#components'
     <div class="container">
       <div class="navbar-menu is-active">
         <div class="navbar-start">
-          <NuxtLink to="/" class="navbar-item">Home</NuxtLink>
-          <NuxtLink to="/about" class="navbar-item">About</NuxtLink>
-          <NuxtLink to="/how-to" class="navbar-item">How-To Guide</NuxtLink>
-          <NuxtLink to="/models-and-uncertainty" class="navbar-item"
+          <NuxtLink to="/" class="navbar-item" @click="trackNavClick('/')"
+            >Home</NuxtLink
+          >
+          <NuxtLink
+            to="/about"
+            class="navbar-item"
+            @click="trackNavClick('/about')"
+            >About</NuxtLink
+          >
+          <NuxtLink
+            to="/how-to"
+            class="navbar-item"
+            @click="trackNavClick('/how-to')"
+            >How-To Guide</NuxtLink
+          >
+          <NuxtLink
+            to="/models-and-uncertainty"
+            class="navbar-item"
+            @click="trackNavClick('/models-and-uncertainty')"
             >Models and Uncertainty</NuxtLink
           >
-          <NuxtLink to="/data" class="navbar-item">Data</NuxtLink>
+          <NuxtLink
+            to="/data"
+            class="navbar-item"
+            @click="trackNavClick('/data')"
+            >Data</NuxtLink
+          >
         </div>
       </div>
     </div>

--- a/webapp/components/Search.vue
+++ b/webapp/components/Search.vue
@@ -67,6 +67,12 @@ onMounted(() => {
     let selection = event.detail.selection.value
     let id = selection.id
 
+    window.trackUmamiEvent('search-selection', {
+      id: id,
+      name: selection.name,
+      region: selection.region,
+    })
+
     if (selection.region === 'conus') {
       navigateTo({
         path: '/',

--- a/webapp/nuxt.config.ts
+++ b/webapp/nuxt.config.ts
@@ -22,12 +22,9 @@ export default defineNuxtConfig({
       script: [
         {
           src: 'https://umami.snap.uaf.edu/script.js',
-          // TODO: replace with the website ID from Umami once the production
-          // site is registered there.
-          'data-website-id': '00000000-0000-0000-0000-000000000000',
+          'data-website-id': 'a5a8e5a7-d390-4919-9502-827c2e1f1ac2',
           // Only track visits on the production domain, not development.
-          // TODO: replace with the finalized production domain.
-          'data-domains': 'hydroviz.snap.uaf.edu',
+          'data-domains': 'hydroviz.org',
           'data-do-not-track': 'true',
           async: 'true',
           defer: 'true',

--- a/webapp/nuxt.config.ts
+++ b/webapp/nuxt.config.ts
@@ -19,6 +19,20 @@ export default defineNuxtConfig({
         { rel: 'icon', type: 'image/svg+xml', href: '/icon.svg' },
         { rel: 'apple-touch-icon', href: '/apple-touch-icon.png' },
       ],
+      script: [
+        {
+          src: 'https://umami.snap.uaf.edu/script.js',
+          // TODO: replace with the website ID from Umami once the production
+          // site is registered there.
+          'data-website-id': '00000000-0000-0000-0000-000000000000',
+          // Only track visits on the production domain, not development.
+          // TODO: replace with the finalized production domain.
+          'data-domains': 'hydroviz.snap.uaf.edu',
+          'data-do-not-track': 'true',
+          async: 'true',
+          defer: 'true',
+        },
+      ],
     },
   },
   runtimeConfig: {

--- a/webapp/plugins/umami.client.ts
+++ b/webapp/plugins/umami.client.ts
@@ -1,0 +1,26 @@
+// Umami analytics event helper.
+//
+// The Umami script itself is loaded from nuxt.config.ts. This plugin defines a
+// global guard function so components can record custom events without caring
+// whether Umami actually loaded (it may be blocked by an ad blocker, or absent
+// entirely during development because of the data-domains restriction).
+declare global {
+  interface Window {
+    umami?: {
+      track: (eventName: string, payload?: Record<string, unknown>) => void
+    }
+    trackUmamiEvent: (
+      eventName: string,
+      payload?: Record<string, unknown>
+    ) => void
+  }
+}
+
+export default defineNuxtPlugin(() => {
+  // Guard in case Umami is not available
+  window.trackUmamiEvent = function (eventName, payload) {
+    if (window.umami && window.umami.track) {
+      window.umami.track(eventName, payload)
+    }
+  }
+})

--- a/webapp/utils/map.ts
+++ b/webapp/utils/map.ts
@@ -214,6 +214,11 @@ export const addSegmentsGeoJson = ({
         const routePrefix =
           region === 'alaska' ? '/alaska/stream' : '/conus/stream'
         const segId = feature.properties[idProperty]
+        window.trackUmamiEvent('segment-click', {
+          id: String(segId),
+          region,
+          map: mapType,
+        })
         navigateTo(routePrefix + '/' + segId)
       })
   })


### PR DESCRIPTION
Closes #177 

For testing, comment out the `data-domains` variable in nuxt.config.ts and run through these (AI generated):


Event | Where | Verified payload
-- | -- | --
nav-click | NavBar.vue | {route: "/about"}
search-selection | Search.vue | {id, name, region}
huc-click | Map.vue:376 | {id: "10300104", name: "Blackwater", region: "conus"}
segment-click | utils/map.ts:214 | {id: "25553", region: "conus", map: "main"}
get-and-use-reached | GetAndUse.vue | see note below
csv-download | CsvDownload.vue | {type: "stats"/"climatology", segment, region}
api-link-click | GetAndUse.vue | {segment: "25553", region: "conus"}




[AI Generated]
Integrates Umami analytics following the pattern used in the alaska-wildfires repository (issue #177):

- Load the Umami script from nuxt.config.ts with data-domains restricted to production so development interactions are not tracked, and data-do-not-track enabled.
- Add a window.trackUmamiEvent guard (plugins/umami.client.ts) so event calls are safe no-ops when Umami is blocked or unavailable.
- Track events: nav-click (page routes), search-selection (name or HUC ID), huc-click (which HUC), segment-click (which segment), get-and-use-reached (scrolled to end of report), csv-download and api-link-click (data downloads).

The data-domain values are placeholders until the production site is registered in Umami and the final domain is known.