### PR TITLE
Switch Alaska base map to USGS National Map (#244)

### DIFF
--- a/webapp/components/Map.vue
+++ b/webapp/components/Map.vue
@@ -19,51 +19,39 @@ const props = defineProps<{
 const region = props.region || 'conus'
 const wfsBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&outputFormat=application%2Fjson`
 
-// Region-specific configuration
+// Region-specific configuration. Both regions share the USGS National Map
+// basemap in EPSG:3857 (Web Mercator); only the data layers and default
+// center differ.
 const regionConfig = {
   conus: {
     mapId: 'map-conus',
-    defaultZoom: 4,
     defaultCenter: [37.8, -96] as [number, number],
-    minZoom: 4,
-    maxZoom: 12,
-    crs: 'EPSG:3857',
     segLayer: 'hydrology:seg_h8_outlet_stats_simplified_subset',
     hucLayer: 'hydrology:huc8_conus_stats_simplified',
-    segBaseUrl: `${wfsBaseUrl}&typeName=hydrology%3Aseg_h8_outlet_stats_simplified_subset`,
     hucBaseUrl: `${wfsBaseUrl}&typeName=hydrology%3Ahuc8&srsName=EPSG:4326`,
   },
   alaska: {
     mapId: 'map-alaska',
-    defaultZoom: 0,
     defaultCenter: [64.2, -152.0] as [number, number],
-    minZoom: 0,
-    maxZoom: 6,
-    crs: 'EPSG:3338',
     segLayer: 'hydrology:arctic_rivers_segments_joined_3338_simplified',
     hucLayer: 'hydrology:arctic_rivers_watersheds_stats_simplified',
-    segBaseUrl: `${wfsBaseUrl}&typeName=hydrology%3Aarctic_rivers_segments_joined_3338_simplified`,
     hucBaseUrl: `${wfsBaseUrl}&typeName=hydrology%3Aarctic_rivers_watersheds_stats_simplified&srsName=EPSG:4326`,
   },
 }
 
 const config = regionConfig[region]
 
-// Per-phase zoom levels for this region.
-let defaultViewZoom: number
-let hucSelectZoom: number
-let segmentSelectZoom: number
+// Zoom limits, shared by both regions. Zoom is program-driven (phases), so
+// these only bound the phase zooms and the basemap tile range.
+const minZoom = 4
+const maxZoom = 12
 
-if (region === 'alaska') {
-  defaultViewZoom = 0 // phase 0
-  hucSelectZoom = 4 // phase 1
-  segmentSelectZoom = 8 // phase 2
-} else {
-  // conus
-  defaultViewZoom = 4
-  hucSelectZoom = 7
-  segmentSelectZoom = 10
-}
+// Per-phase zoom levels. Alaska's Phase 1 sits one level deeper than CONUS
+// so its ground scale (~256 m/px at Alaska's latitude, where Mercator tiles
+// are compressed) matches the view the old EPSG:3338 tile scheme gave.
+const defaultViewZoom = 4 // phase 0
+const hucSelectZoom = region === 'alaska' ? 8 : 7 // phase 1
+const segmentSelectZoom = 10 // phase 2
 
 // Query param keys per region for phase + HUC + center tracking.
 const paramKeys =
@@ -192,10 +180,10 @@ const fetchHuc = async (hucId: string) => {
   return r.json()
 }
 
-// The Phase 2 zoom is pinned to segmentSelectZoom (clamped to the map's max).
-// fitBounds would otherwise zoom out to fit large HUCs, packing the stream
-// network too densely; this is also the value that caps zoom-in for small HUCs.
-const phase2Zoom = () => Math.min(segmentSelectZoom, config.maxZoom)
+// The Phase 2 zoom is pinned to segmentSelectZoom. fitBounds would otherwise
+// zoom out to fit large HUCs, packing the stream network too densely; this is
+// also the value that caps zoom-in for small HUCs.
+const phase2Zoom = () => segmentSelectZoom
 
 // Saved center from the URL ([lat, lng]), or null if absent/invalid. A fresh
 // HUC click clears these, so a present value means we are restoring a Phase 2
@@ -443,48 +431,19 @@ const initializeMap = () => {
     touchZoom: false,
     keyboard: false,
     zoomSnap: 0.1,
-    minZoom: Math.min(config.minZoom, defaultViewZoom),
-    maxZoom: config.maxZoom,
-  }
-
-  let proj: any = null
-
-  if (config.crs === 'EPSG:3338') {
-    let resolutions = [4096, 2048, 1024, 512, 256, 128, 64]
-    proj = new $L.Proj.CRS(
-      'EPSG:3338',
-      '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
-      {
-        // Lower-left corner of GeoServer's gridset bounds for EPSG:3338
-        origin: [-4648005.934316417, 444809.882955059],
-        resolutions: resolutions,
-      }
-    )
-    mapOptions.crs = proj
+    minZoom: minZoom,
+    maxZoom: maxZoom,
   }
 
   const view = initialView()
   map = $L.map(config.mapId, mapOptions).setView(view.center, view.zoom)
 
-  if (config.mapId === 'map-conus') {
-    $L.tileLayer(
-      'https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}',
-      {
-        attribution: 'Map data © USGS',
-      }
-    ).addTo(map)
-  } else if (config.mapId === 'map-alaska') {
-    let url = `${$config.public.geoserverUrl}/wms`
-    $L.tileLayer
-      .wms(url, {
-        transparent: true,
-        crs: proj,
-        format: 'image/png',
-        version: '1.3.0',
-        layers: 'atlas_mapproxy:alaska_osm_retina',
-      })
-      .addTo(map)
-  }
+  $L.tileLayer(
+    'https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}',
+    {
+      attribution: 'Map data © USGS',
+    }
+  ).addTo(map)
 
   // Create the phase-managed layers detached; the phase functions add/remove them.
   hucWmsLayer = $L.tileLayer.wms(`${$config.public.geoserverUrl}/wms`, {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -15,14 +15,11 @@
         "lodash": "^4.17.21",
         "nuxt": "^4.2.2",
         "plotly.js": "^3.4.0",
-        "proj4": "^2.20.8",
-        "proj4leaflet": "^1.0.2",
         "vue": "latest",
         "vue-router": "latest"
       },
       "devDependencies": {
         "@types/leaflet": "^1.9.14",
-        "@types/proj4leaflet": "^1.0.12",
         "prettier": "^3.3.3",
         "sass": "^1.80.6"
       },
@@ -7195,18 +7192,6 @@
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "license": "MIT"
     },
-    "node_modules/@types/proj4leaflet": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@types/proj4leaflet/-/proj4leaflet-1.0.12.tgz",
-      "integrity": "sha512-SkWDAdQK3ddPSq995UGYe/WZODQR1bf3CDMjp+S7cq9+AnISSIhKr8vUQ7g/hMAWYNiNIFjH/atTcMAkNl3c9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*",
-        "@types/leaflet": "^1.9",
-        "proj4": "^2.19.0"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -11563,12 +11548,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/mgrs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
-      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
-      "license": "MIT"
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -13802,28 +13781,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
-    },
-    "node_modules/proj4": {
-      "version": "2.20.8",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.8.tgz",
-      "integrity": "sha512-1C8sfT4xY4PAPwk0MroFBTGF4R4bzDXdmPQTGYVLsoNssrZ9odzObxS2dTeGBty8jW8KO7h16C1Hs2JP+ctfFw==",
-      "license": "MIT",
-      "dependencies": {
-        "mgrs": "1.0.0",
-        "wkt-parser": "^1.5.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ahocevar"
-      }
-    },
-    "node_modules/proj4leaflet": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/proj4leaflet/-/proj4leaflet-1.0.2.tgz",
-      "integrity": "sha512-6GdDeUlhX/tHUiMEj80xQhlPjwrXcdfD0D5OBymY8WvxfbmZcdhNqQk7n7nFf53ue6QdP9ls9ZPjsAxnbZDTsw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "proj4": "^2.3.14"
-      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -16127,15 +16084,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/wkt-parser": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.5.tgz",
-      "integrity": "sha512-/zMYi94/7D7fxcOSlVmWn6vnOMj3Gq5d1xvVjaYOS9n6h0qOJ4I7YYVxBWYcH1vq9+suhqzXkn05Yx47zQNUIA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ahocevar"
       }
     },
     "node_modules/world-calendars": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -21,14 +21,11 @@
     "lodash": "^4.17.21",
     "nuxt": "^4.2.2",
     "plotly.js": "^3.4.0",
-    "proj4": "^2.20.8",
-    "proj4leaflet": "^1.0.2",
     "vue": "latest",
     "vue-router": "latest"
   },
   "devDependencies": {
     "@types/leaflet": "^1.9.14",
-    "@types/proj4leaflet": "^1.0.12",
     "prettier": "^3.3.3",
     "sass": "^1.80.6"
   }

--- a/webapp/plugins/proj4leaflet.client.ts
+++ b/webapp/plugins/proj4leaflet.client.ts
@@ -1,9 +1,0 @@
-import proj4leaflet from 'proj4leaflet'
-
-export default defineNuxtPlugin(nuxtApp => {
-  return {
-    provide: {
-      proj4leaflet,
-    },
-  }
-})


### PR DESCRIPTION
Closes #244 
Refs #223 

Testing: just ensure the Alaska map works properly.

[AI Generated summary]
Use the same USGS National Map basemap (EPSG:3857) for the Alaska map as CONUS, replacing the EPSG:3338 GeoServer WMS basemap. This gives much better map detail at higher zoom levels and lets both regions share a single map configuration.

- Remove the custom Proj.CRS EPSG:3338 setup and the region-specific basemap branch; both maps now use Leaflet's default Web Mercator CRS, so the HUC/segment WMS overlays are requested in EPSG:3857 as well.
- Translate Alaska's phase zooms from the old 3338 tile scheme into equivalent Web Mercator zooms (overview 4, HUC select 8, segment select 10), preserving the previous ground scale at Alaska latitudes.
- Consolidate regionConfig: drop the per-region crs/min/max zoom and the unused defaultZoom and segBaseUrl entries.
- Remove the now-unused proj4leaflet plugin and its dependencies.