### PR TITLE
Fix "scenario is not defined" error for Alaska stream segments

### DIFF
--- a/webapp/components/Viz/MaxFlowDates.vue
+++ b/webapp/components/Viz/MaxFlowDates.vue
@@ -91,9 +91,6 @@ const buildChart = () => {
         symbol: scenarioSymbols['historical'],
       },
     }
-    if (appContext.value === 'extremes' && scenario === 'rcp45') {
-      historicalTrace['subplot'] = 'polar2'
-    }
 
     historicalTraces.push(historicalTrace)
 

--- a/webapp/pages/alaska/stream/[segment].vue
+++ b/webapp/pages/alaska/stream/[segment].vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useStreamSegmentStore } from '~/stores/streamSegment'
 const streamSegmentStore = useStreamSegmentStore()
-let { segmentId, segmentRegion } = storeToRefs(streamSegmentStore)
+let { segmentId, segmentRegion, appContext } = storeToRefs(streamSegmentStore)
 
 const route = useRoute()
 let segment = parseInt(route.params.segment)
@@ -26,6 +26,10 @@ if (
 // Set + fetch data.
 segmentId.value = segment
 segmentRegion.value = 'alaska'
+
+// Alaska reports don't offer the middle-of-the-road/future-extremes toggle,
+// so clear any "extremes" context carried over from a CONUS report.
+appContext.value = 'mid'
 </script>
 
 <template>


### PR DESCRIPTION
Fixes #247

[AI Generated below, accurate + STR is good: CONUS report → "future extremes" → back to front page → Alaska report = bomb]

## Problem

The mid / future-extremes toggle state (`appContext`) lives in the Pinia store and survives navigation, but Alaska reports never render the toggle (`Report.vue` only shows `StickyToggle` for CONUS). After switching a CONUS report to "future extremes" and then selecting an Alaska stream segment, the Alaska charts ran with a stale `'extremes'` context.

In the Alaska branch of `MaxFlowDates.vue`, a leftover condition referenced a variable `scenario` that only exists in the CONUS code path (inside `scenarios.forEach(scenario => ...)`). In `'mid'` mode the `&&` short-circuited past it, but in `'extremes'` mode it evaluated and threw `ReferenceError: scenario is not defined`, which surfaced as the Error 500 page shown in the issue. Beyond the crash, the polar charts would also have laid themselves out squeezed into half width with a phantom second subplot.

## Fix

- **`pages/alaska/stream/[segment].vue`**: reset `appContext` to `'mid'` when an Alaska report loads, right where `segmentRegion` is set. Extremes mode is a CONUS-only concept, so this fixes the whole class of problem (crash + layout issues) for every Alaska chart.
- **`components/Viz/MaxFlowDates.vue`**: remove the dead block that referenced the undefined `scenario`; the Alaska historical trace never belongs on a second subplot.

## Verification

Replicated the issue's exact steps in the dev server (using static fixtures): CONUS report → "future extremes" → back to front page → Alaska report.

- **Before**: error page with `Error 500 — scenario is not defined`, matching the issue screenshot.
- **After**: the Alaska report renders fully — the store confirms `appContext` resets to `mid`, the max-flow-dates chart draws as a single full-width polar plot with its Projected and Historical traces, and there are zero console errors.
- **No CONUS regression**: extremes mode still renders the dual hydrographs and dual polar plots with RCP 4.5/8.5 traces, and mid mode still renders the single RCP 6.0 plot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)