### PR TITLE
Add initial version of Alaska chart/table intro text

### DIFF
--- a/webapp/components/Report.vue
+++ b/webapp/components/Report.vue
@@ -92,6 +92,14 @@ onUnmounted(() => {
             climate models are shown in each chart (top and bottom lines), and
             the range of variation for the means are shown as a shaded ribbon.
           </p>
+          <p v-if="segmentRegion == 'alaska'">
+            The chart below is a hydrograph that shows the modeled historical
+            mean (white line in center) and range of variation (gray band) with
+            the projected scenario&mdash;{{ scenarioFullNames.ssp370 }}. The
+            minimum and maximum across four climate model runs are shown (the
+            top and bottom lines), and the range of variation for the means are
+            shown as a shaded ribbon.
+          </p>
         </div>
         <VizHydrograph :stream-hydrograph="streamHydrograph" />
       </div>
@@ -121,6 +129,16 @@ onUnmounted(() => {
             a line inside the box. The whiskers span &#177;1.5 times the
             interquartile range, and outliers are shown as colored dots.
           </p>
+          <p v-if="segmentRegion == 'alaska'">
+            The chart below shows the mean modeled monthly flow rate for the
+            historical modeled value (diamond) and with the projected
+            scenario&mdash;{{ scenarioFullNames.ssp370 }}. The box plot shows
+            the range of values for four climate model runs. Each box plot spans
+            from quartile 1 to quartile 3, which is the interquartile range
+            (IQR). The second quartile&mdash;the median&mdash;is marked by a
+            line inside the box. The whiskers span &#177;1.5 times the
+            interquartile range, and outliers are shown as colored dots.
+          </p>
         </div>
         <VizMonthlyFlow :stream-monthly-flow="streamMonthlyFlow" />
       </div>
@@ -144,6 +162,14 @@ onUnmounted(() => {
             13 climate models. This chart can help you see changes in the timing
             and magnitude of annual maximum flow rates.
           </p>
+          <p v-if="segmentRegion == 'alaska'">
+            The chart below shows the modeled annual maximum daily flow rate and
+            the date of its occurrence for the historical modeled value
+            (diamond) and with the projected scenario,
+            {{ scenarioFullNames.ssp370 }}, for four climate model runs. This
+            chart can help you see changes in the timing and magnitude of annual
+            maximum flow rates.
+          </p>
         </div>
         <VizMaxFlowDates :stream-max-flow-dates="streamMaxFlowDates" />
       </div>
@@ -151,11 +177,34 @@ onUnmounted(() => {
 
     <section class="section" v-if="segmentRegion == 'alaska'">
       <div class="container">
+        <div class="content clamp is-size-5 mb-6">
+          <p>
+            The chart below is a temperature hydrograph that shows the modeled
+            historical mean (white line in center) and range of variation (gray
+            band) with the projected scenario&mdash;{{
+              scenarioFullNames.ssp370
+            }}. The minimum and maximum across four climate model runs are shown
+            (the top and bottom lines), and the range of variation for the means
+            are shown as a shaded ribbon.
+          </p>
+        </div>
         <VizTemperatureHydrograph :stream-wt-hydrograph="streamWtHydrograph" />
       </div>
     </section>
     <section class="section" v-if="segmentRegion == 'alaska'">
       <div class="container">
+        <div class="content clamp is-size-5 mb-6">
+          <p>
+            The chart below shows the mean modeled monthly temperature for the
+            historical modeled value (diamond) and with the projected
+            scenario&mdash;{{ scenarioFullNames.ssp370 }}. The box plot shows
+            the range of values for four climate model runs. Each box plot spans
+            from quartile 1 to quartile 3, which is the interquartile range
+            (IQR). The second quartile&mdash;the median&mdash;is marked by a
+            line inside the box. The whiskers span &#177;1.5 times the
+            interquartile range, and outliers are shown as colored dots.
+          </p>
+        </div>
         <VizMonthlyTemperature
           :stream-monthly-temperature="streamMonthlyTemperature"
         />
@@ -163,6 +212,16 @@ onUnmounted(() => {
     </section>
     <section class="section" v-if="segmentRegion == 'alaska'">
       <div class="container">
+        <div class="content clamp is-size-5 mb-6">
+          <p>
+            The chart below shows the modeled annual maximum temperature and the
+            date of its occurrence for the historical modeled value (diamond)
+            and with the projected scenario,
+            {{ scenarioFullNames.ssp370 }}, for four climate model runs. This
+            chart can help you see changes in the timing and magnitude of annual
+            maximum temperatures.
+          </p>
+        </div>
         <VizMaxTemperatureDates :stream-max-temp-dates="streamMaxTempDates" />
       </div>
     </section>
@@ -187,6 +246,11 @@ onUnmounted(() => {
             &lsquo;Maximum, {{ scenarioFullNames.rcp85 }}&rsquo; column are the
             maximum values across all 13 climate models for the
             {{ scenarioFullNames.rcp85 }} scenario.
+          </p>
+          <p v-if="segmentRegion == 'alaska'">
+            The projected values in the tables below show the median values
+            across the {{ scenarioFullNames.ssp370 }} climate scenario for four
+            climate model runs.
           </p>
         </div>
         <StatsTable


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/201

Note: This PR branches off of the `alaska_chart_text` branch to take advantage of the new SSP3-7.0 scenario label, so I'm going to put this PR in draft mode until `alaska_chart_text` is merged.

This PR adds an intro blurb above each of the six charts (+ tables) on Alaska report pages. This text is meant to be a good start, but tentative. Each blurb mentions that the projected data are from four model _runs_, not four _models_, since the four projected data points are all runs from the CESM2 model. The term _model runs_ is consistent with how they are described on the Data API page for the Arctic Hydrology endpoints.

Since we're dealing with four projected data points under the same scenario, and the two pseudo-global warming model data points (under a different scenario) have been removed from all charts and table statistics (https://github.com/ua-snap/data-api/pull/731), there is less to explain and the chart/table intro text blurbs ended up being very similar to the CONUS chart/table intro text blurbs.