### PR TITLE
Fix Alaska outlets not marked red on main map

### DIFF
--- a/webapp/utils/map.ts
+++ b/webapp/utils/map.ts
@@ -105,19 +105,15 @@ export const addSegmentsGeoJson = ({
   }
 
   orderedSegments.forEach((feature: any) => {
-    let isSelected: boolean = false
-    if (segmentRegion.value === 'alaska') {
-      isSelected = (selectedSegmentId &&
-        feature.properties.COMID === selectedSegmentId) as boolean
-    } else {
-      isSelected = (selectedSegmentId &&
-        feature.properties.seg_id_nat === selectedSegmentId) as boolean
-    }
+    let isSelected = (selectedSegmentId &&
+      feature.properties[idProperty] === selectedSegmentId) as boolean
 
     let interactive = !isSelected
     let selectedKey = isSelected ? 'selected' : 'unselected'
-    let outletProperty =
-      segmentRegion.value === 'alaska' ? 'outlet' : 'h8_outlet'
+    // The WFS layers use different property names for outlet status:
+    // 'outlet' for Alaska, 'h8_outlet' for CONUS. Use the resolved region
+    // (not segmentRegion, which is null on the main map pages).
+    let outletProperty = region === 'alaska' ? 'outlet' : 'h8_outlet'
     let outletKey =
       feature.properties[outletProperty] === 1 ? 'outlet' : 'regular'
     let segmentColor = segmentColors[mapType][selectedKey][outletKey]


### PR DESCRIPTION
Fixes #233.

Alaska outflow segments weren't being colored red.  This fixes that.  

[AI generated stuff]

## Root cause

`addSegmentsGeoJson` in `webapp/utils/map.ts` chose the outlet property name based on `segmentRegion` from the Pinia store — but that value is only set on segment report pages, and `Map.vue` explicitly resets it to `null` when the main map mounts. On the main Alaska map this fell through to the CONUS branch and looked up `h8_outlet`, which doesn't exist in the Alaska WFS layer, so every segment (outlets included) rendered blue. CONUS only worked by coincidence, because `null` lands in the correct branch. This is also why the report map's outlets were unaffected.

The fix uses the resolved `region` already computed at the top of the function (`segmentRegion.value || mapRegion`, where `mapRegion` is passed by every caller). The `isSelected` check is also collapsed to use the already-resolved `idProperty` rather than repeating the same store-based branch.

Note the property names themselves were already correct — the issue's suggestion to rename `outlet` to `huc8_outlet` would have broken the (working) report map. Verified against the live GeoServer: the Alaska layer `arctic_rivers_segments_joined_3338_simplified` serves `outlet` (int 0/1, 240 outlets of 34,497 segments) and the CONUS layer serves `h8_outlet` (int 0/1). `huc8_outlet` is the *stats API* key, which `stores/streamSegment.ts` already handles separately.

## Testing instructions

1. Run the dev server (`npm run dev` in `webapp/`). Static fixtures (`HYDROVIZ_USE_STATIC_FIXTURES=true`) are fine for the report-page check but not required; map symbology comes from live WFS either way.
2. **Alaska main map (the bug):** open
   `http://localhost:3000/?ap=2&ahuc=19060203&alat=70.84&alng=-155.93`
   and scroll to the Alaska map. This is the Meade River watershed panned to its coastal outlet on Admiralty Bay. Expect the outlet segments (and their circle handles) to be red among the blue segments. Before this fix, everything was blue.
3. **CONUS main map (regression):** open
   `http://localhost:3000/?cp=2&chuc=01010002&clat=46.816&clng=-69.233`
   (Allagash River watershed). Outlet segments should still be red, as before.
4. **Alaska report page (regression):** open `http://localhost:3000/alaska/stream/81000005`. The selected outlet segment on the report map should be red, and with static fixtures enabled the intro should read "This stream segment is an outflow segment for …".

🤖 Generated with [Claude Code](https://claude.com/claude-code)