### PR TITLE
Add one line of explainer text to the footer of each chart

### DIFF
--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -87,8 +87,10 @@ const getLayoutPositions = (
   let marginTop: null | number = null
   let marginBottom: null | number = null
   let footerY: null | number = null
-  let generalizedChartType = generalizedChartTypes[chartType]
-
+  const generalizedChartType = generalizedChartTypes[chartType]
+  if (!generalizedChartType) {
+    throw new Error(`Unknown chartType "${chartType}"`)
+  }
   if (isTwoLineTitle) {
     if (isAlaskaData) {
       if (generalizedChartType === 'hydrograph') {

--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -1,6 +1,15 @@
 import type { Config, Layout } from 'plotly.js'
 import lowess from '@stdlib/stats-lowess'
 
+const generalizedChartTypes: Record<string, string> = {
+  hydrograph: 'hydrograph',
+  temperatureHydrograph: 'hydrograph',
+  monthlyFlow: 'monthlyBoxPlots',
+  monthlyTemperature: 'monthlyBoxPlots',
+  maxFlowDates: 'maxDates',
+  maxTempDates: 'maxDates',
+}
+
 export const getConfig = (filename: string): Partial<Config> => {
   return {
     responsive: true, // changes the height / width dynamically for charts
@@ -31,15 +40,37 @@ export const getGageIdLine = (gageId: string | null): string => {
     : ''
 }
 
-const getFooterCredits = (isAlaskaData: boolean): string => {
-  if (isAlaskaData) {
-    return 'Data provided by Dylan Blaskey, Keith Musselman, Andrew Newman, &amp; Yifan Cheng. (2024). doi:10.18739/A25M62870'
+const getFooterText = (isAlaskaData: boolean, chartType: string): string => {
+  let projectedModels = isAlaskaData
+    ? 'four climate model runs'
+    : '13 climate models'
+
+  let historicalModel = isAlaskaData
+    ? 'a dynamically downscaled ERA5 baseline'
+    : 'Maurer calibration'
+
+  let generalizedChartType = generalizedChartTypes[chartType]!
+
+  let footerText = ''
+
+  if (generalizedChartType == 'hydrograph') {
+    footerText += `Projected range is from ${projectedModels}, historical range is from ${historicalModel}.<br>`
   } else {
-    return (
+    // Make the first letter of projectedModels uppercase for the footer text.
+    projectedModels =
+      projectedModels.charAt(0).toUpperCase() + projectedModels.slice(1)
+    footerText += `${projectedModels} are shown as a distribution, historical is ${historicalModel}.<br>`
+  }
+
+  if (isAlaskaData) {
+    footerText +=
+      'Data provided by Dylan Blaskey, Keith Musselman, Andrew Newman, &amp; Yifan Cheng. (2024). doi:10.18739/A25M62870'
+  } else {
+    footerText +=
       'Historical data provided by U.S. Geological Survey National Water Information System. doi:10.5066/F7P55KJN<br>' +
       'Projected data provided by LaFontaine, J.H., and Riley, J.W., 2023. doi:10.5066/P9EBKREQ'
-    )
   }
+  return footerText
 }
 
 // Keep plot area, footer position, and margins consistent across chart types.
@@ -53,88 +84,78 @@ const getLayoutPositions = (
   let marginTop: null | number = null
   let marginBottom: null | number = null
   let footerY: null | number = null
-
-  const generalizedChartTypes: Record<string, string> = {
-    hydrograph: 'hydrograph',
-    temperatureHydrograph: 'hydrograph',
-    monthlyFlow: 'monthlyBoxPlots',
-    monthlyTemperature: 'monthlyBoxPlots',
-    maxFlowDates: 'maxDates',
-    maxTempDates: 'maxDates',
-  }
-
   let generalizedChartType = generalizedChartTypes[chartType]
 
   if (isTwoLineTitle) {
     if (isAlaskaData) {
       if (generalizedChartType === 'hydrograph') {
-        height = 515
+        height = 542
         marginTop = 100
-        marginBottom = 145
-        footerY = -0.5
+        marginBottom = 167
+        footerY = -0.52
       } else if (generalizedChartType === 'monthlyBoxPlots') {
-        height = 535
+        height = 545
+        marginTop = 120
+        marginBottom = 150
+        footerY = -0.45
+      } else if (generalizedChartType === 'maxDates') {
+        height = 570
         marginTop = 120
         marginBottom = 140
-        footerY = -0.44
-      } else if (generalizedChartType === 'maxDates') {
-        height = 560
-        marginTop = 120
-        marginBottom = 130
-        footerY = -0.35
+        footerY = -0.37
       }
     } else {
       if (generalizedChartType === 'hydrograph') {
-        height = 535
+        height = 552
         marginTop = 100
-        marginBottom = 160
-        footerY = -0.55
+        marginBottom = 177
+        footerY = -0.57
       } else if (generalizedChartType === 'monthlyBoxPlots') {
-        height = 520
+        height = 540
         marginTop = 100
-        marginBottom = 145
-        footerY = -0.48
+        marginBottom = 165
+        footerY = -0.5
       } else if (generalizedChartType === 'maxDates') {
-        height = 555
+        height = 575
         marginTop = 120
-        marginBottom = 130
-        footerY = -0.4
+        marginBottom = 150
+        footerY = -0.42
       }
     }
   } else {
     if (isAlaskaData) {
       if (generalizedChartType === 'hydrograph') {
-        height = 505
+        height = 522
         marginTop = 80
-        marginBottom = 150
-        footerY = -0.5
+        marginBottom = 167
+        footerY = -0.52
       } else if (generalizedChartType === 'monthlyBoxPlots') {
-        height = 505
+        height = 525
         marginTop = 100
-        marginBottom = 130
-        footerY = -0.43
+        marginBottom = 150
+        footerY = -0.45
       } else if (generalizedChartType === 'maxDates') {
-        height = 530
+        height = 550
         marginTop = 100
-        marginBottom = 120
-        footerY = -0.35
+        marginBottom = 140
+        footerY = -0.37
       }
     } else {
       if (generalizedChartType === 'hydrograph') {
-        height = 520
+        height = 532
+        marginTop = 80
+        marginBottom = 177
+        footerY = -0.57
+      } else if (generalizedChartType === 'monthlyBoxPlots') {
+        height = 525
         marginTop = 80
         marginBottom = 165
-        footerY = -0.55
-      } else if (generalizedChartType === 'monthlyBoxPlots') {
-        height = 505
-        marginTop = 80
-        marginBottom = 145
-        footerY = -0.48
+        footerY = -0.5
       } else if (generalizedChartType === 'maxDates') {
-        height = 535
+        height = 555
         marginTop = 100
-        marginBottom = 130
-        footerY = -0.4
+        marginBottom = 150
+        footerY = -0.42
       }
     }
   }
@@ -197,7 +218,7 @@ export const getLayout = (
     hovermode: false,
     annotations: [
       {
-        text: getFooterCredits(isAlaskaData),
+        text: getFooterText(isAlaskaData, chartType),
         xref: 'paper',
         yref: 'paper',
         x: 0.5,

--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -49,11 +49,14 @@ const getFooterText = (isAlaskaData: boolean, chartType: string): string => {
     ? 'a dynamically downscaled ERA5 baseline'
     : 'Maurer calibration'
 
-  let generalizedChartType = generalizedChartTypes[chartType]!
+  const generalizedChartType = generalizedChartTypes[chartType]
+  if (!generalizedChartType) {
+    throw new Error(`Unknown chartType "${chartType}"`)
+  }
 
   let footerText = ''
 
-  if (generalizedChartType == 'hydrograph') {
+  if (generalizedChartType === 'hydrograph') {
     footerText += `Projected range is from ${projectedModels}, historical range is from ${historicalModel}.<br>`
   } else {
     // Make the first letter of projectedModels uppercase for the footer text.


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/141.

This PR adds a single line of "explainer text" to the bottom of each chart to help clarify what is plotted, and to travel with the chart when exported to PNG. It also makes small tweaks to footer margins and positioning to make room for the extra footer line and keep chart spacing consistent across all charts.

I'm reusing the same text for monthly boxplot charts, and max value & date radial charts, since it seems to me that the same text applies to each. The hydrograph (and temperature hydrographs) have separate text since the full range of individual values is not visible on these charts, although the same could be said of the box plots I suppose. Anyway, this is just a first effort that is likely to be revised later.

To test, read the footer text for all CONUS and Alaska charts, and observe that the margins/spacing/positioning still looks good for Gage vs. no-Gage (i.e., 1-one-title vs. 2-line-title) charts also. Here are some example stream segments to test:

- A CONUS stream segment with a corresponding USGS gage (e.g., http://localhost:3000/conus/stream/51206)
- An Alaska stream segment with a corresponding USGS gage (e.g., http://localhost:3000/alaska/stream/81033944)
- A CONUS stream segment without a corresponding USGS gage (e.g., http://localhost:3000/conus/stream/33812)
- An Alaska stream segment without a corresponding USGS gage (e.g., http://localhost:3000/alaska/stream/81029424)