### PR TITLE
Add citations to Alaska report pages and move citations into separate CONUS vs. Alaska components

### DIFF
--- a/webapp/components/Citations/Alaska.vue
+++ b/webapp/components/Citations/Alaska.vue
@@ -1,0 +1,75 @@
+<template>
+  <div>
+    <h4 class="title is-4">Academic citations</h4>
+
+    <blockquote>
+      Blaskey D., K. Musselman, A. Newman, &amp; Y. Cheng (2024). Alaskan river
+      discharge, temperature, and climate data for a climate reference
+      (1990-2021) and at mid-century (2034-2065). Arctic Data Center,
+      <a href="https://doi.org/10.18739/A25M62870"
+        >https://doi.org/10.18739/A25M62870</a
+      >.
+    </blockquote>
+
+    <blockquote>
+      Yamazaki D., D. Ikeshima, J. Sosa, P.D. Bates, G.H. Allen, T.M. Pavelsky
+      (2019). MERIT Hydro: A high-resolution global hydrography map based on
+      latest topography datasets. Water Resources Research,
+      <a href="https://doi.org/10.1029/2019WR024873"
+        >https://doi.org/10.1029/2019WR024873</a
+      >.
+    </blockquote>
+
+    <blockquote>
+      Cassano, J. J., A. DuVivier, A. Roberts, M. Hughes, M. Seefeldt, M.
+      Brunke, A. Craig, B. Fisel, W. Gutowski, J. Hamman, M. Higgins, W.
+      Maslowski, B. Nijssen, R. Osinski, &amp; X. Zeng (2017). Development of the
+      Regional Arctic System Model (RASM): Near-Surface Atmospheric Climate
+      Sensitivity. Journal of Climate,
+      <a href="https://doi.org/10.1175/JCLI-D-15-0775.1"
+        >https://doi.org/10.1175/JCLI-D-15-0775.1</a
+      >.
+    </blockquote>
+
+    <blockquote>
+      Rodgers K. B., S.-S. Lee, N. Rosenbloom, A. Timmermann, G. Danabasoglu, C.
+      Deser, J. Edwards, J.-E. Kim, I. R. Simpson, K. Stein, M. F. Stuecker, R.
+      Yamaguchi, T. Bódai, E.-S. Chung, L. Huang, W. M. Kim, J.-F. Lamarque, D.
+      L. Lombardozzi, W. R. Wieder, &amp; S. G. Yeager (2021). Ubiquity of
+      human-induced changes in climate variability. Earth System Dynamics,
+      <a href="https://doi.org/10.5194/esd-12-1393-2021"
+        >https://doi.org/10.5194/esd-12-1393-2021</a
+      >.
+    </blockquote>
+
+    <blockquote>
+      Blaskey D., M. N. Gooseff, Y. Cheng, A. J. Newman, J. C. Koch, &amp; K. N.
+      Musselman (2024). A high-resolution, daily hindcast (1990–2021) of Alaskan
+      river discharge and temperature from coupled and optimized physical
+      models. Water Resources Research,
+      <a href="https://doi.org/10.1029/2023WR036217"
+        >https://doi.org/10.1029/2023WR036217</a
+      >.
+    </blockquote>
+
+    <blockquote>
+      Cheng Y., A. Craig, K. Musselman, A. Bennett, M. Seefeldt, J. Hamman, &amp; A.
+      J. Newman (2024). Coupled high-resolution land-atmosphere modeling for
+      hydroclimate and terrestrial hydrology in Alaska and the Yukon River Basin
+      (1990–2021). Journal of Geophysical Research: Atmospheres,
+      <a href="https://doi.org/10.1029/2024JD041185"
+        >https://doi.org/10.1029/2024JD041185</a
+      >.
+    </blockquote>
+
+    <blockquote>
+      Cheng Y., A. Craig, K. Musselman, &amp; A. Newman (2024). Multi-decadal
+      historical regional hydroclimate simulation with two mid 21st century
+      pseudo-global warming futures over Alaska and the Yukon at 4 km
+      resolution. NSF National Center for Atmospheric Research,
+      <a href="https://doi.org/10.5065/ZPSB-PS82"
+        >https://doi.org/10.5065/ZPSB-PS82</a
+      >.
+    </blockquote>
+  </div>
+</template>

--- a/webapp/components/Citations/Conus.vue
+++ b/webapp/components/Citations/Conus.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <h4 class="title is-4">Academic citations</h4>
+
+    <blockquote>
+      LaFontaine, J.H., and Riley, J.W., 2023, Model Input and Output for
+      Hydrologic Simulations for the Conterminous United States for Historical
+      and Future Conditions Using the National Hydrologic Model Infrastructure
+      (NHM) and the Coupled Model Intercomparison Project Phase 5 (CMIP5),
+      1950–2100: U.S. Geological Survey data release,
+      <a href="https://doi.org/10.5066/P9EBKREQ"
+        >https://doi.org/10.5066/P9EBKREQ</a
+      >.
+    </blockquote>
+
+    <blockquote>
+      Regan, R.S., Markstrom, S.L., Hay, L.E., Viger, R.J., Norton, P.A.,
+      Driscoll, J.M., LaFontaine, J.H., 2018, Description of the National
+      Hydrologic Model for use with the Precipitation–Runoff Modeling System
+      (PRMS): U.S. Geological Survey Techniques and Methods, book 6, chap B9, 38
+      p.,
+      <a href="https://doi.org/10.3133/tm6B9">https://doi.org/10.3133/tm6B9</a>.
+    </blockquote>
+
+    <blockquote>
+      LaFontaine, J.H., Hay, L.E., and Riley, J.R., 2023, Application of the
+      National Hydrologic Model Infrastructure with the Precipitation–Runoff
+      Modeling System (NHM-PRMS), 1950–2010, Maurer Calibration: U.S. Geological
+      Survey data release,
+      <a href="https://doi.org/10.5066/P9CVHLMB"
+        >https://doi.org/10.5066/P9CVHLMB</a
+      >.
+    </blockquote>
+
+    <blockquote>
+      U.S. Geological Survey, 2025, U.S. Geological Survey National Water
+      Information System database, at
+      <a href="https://doi.org/10.5066/F7P55KJN"
+        >https://doi.org/10.5066/F7P55KJN</a
+      >. Data download directly accessible at
+      <a href="https://api.waterdata.usgs.gov/ogcapi/v0/collections/daily"
+        >https://api.waterdata.usgs.gov/ogcapi/v0/collections/daily</a
+      >.
+    </blockquote>
+  </div>
+</template>

--- a/webapp/components/GetAndUse.vue
+++ b/webapp/components/GetAndUse.vue
@@ -81,52 +81,8 @@ onUnmounted(() => {
             (PRMS)
           </li>
         </ul>
-        <div v-if="segmentRegion == 'conus'">
-          <h4 class="title is-4">Academic citations</h4>
-
-          <blockquote>
-            LaFontaine, J.H., and Riley, J.W., 2023, Model Input and Output for
-            Hydrologic Simulations for the Conterminous United States for
-            Historical and Future Conditions Using the National Hydrologic Model
-            Infrastructure (NHM) and the Coupled Model Intercomparison Project
-            Phase 5 (CMIP5), 1950–2100: U.S. Geological Survey data release,
-            <a href="https://doi.org/10.5066/P9EBKREQ"
-              >https://doi.org/10.5066/P9EBKREQ</a
-            >.
-          </blockquote>
-
-          <blockquote>
-            Regan, R.S., Markstrom, S.L., Hay, L.E., Viger, R.J., Norton, P.A.,
-            Driscoll, J.M., LaFontaine, J.H., 2018, Description of the National
-            Hydrologic Model for use with the Precipitation–Runoff Modeling
-            System (PRMS): U.S. Geological Survey Techniques and Methods, book
-            6, chap B9, 38 p.,
-            <a href="https://doi.org/10.3133/tm6B9"
-              >https://doi.org/10.3133/tm6B9</a
-            >.
-          </blockquote>
-
-          <blockquote>
-            LaFontaine, J.H., Hay, L.E., and Riley, J.R., 2023, Application of
-            the National Hydrologic Model Infrastructure with the
-            Precipitation–Runoff Modeling System (NHM-PRMS), 1950–2010, Maurer
-            Calibration: U.S. Geological Survey data release,
-            <a href="https://doi.org/10.5066/P9CVHLMB"
-              >https://doi.org/10.5066/P9CVHLMB</a
-            >.
-          </blockquote>
-
-          <blockquote>
-            U.S. Geological Survey, 2025, U.S. Geological Survey National Water
-            Information System database, at
-            <a href="https://doi.org/10.5066/F7P55KJN"
-              >https://doi.org/10.5066/F7P55KJN</a
-            >. Data download directly accessible at
-            <a href="https://api.waterdata.usgs.gov/ogcapi/v0/collections/daily"
-              >https://api.waterdata.usgs.gov/ogcapi/v0/collections/daily</a
-            >.
-          </blockquote>
-        </div>
+        <CitationsConus v-if="segmentRegion == 'conus'" />
+        <CitationsAlaska v-if="segmentRegion == 'alaska'" />
       </div>
     </div>
   </section>


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/204

This PR adds citations to Alaska report pages, using the same set of citations as the Arctic Hydrology API endpoint documentation. It also splits the citations into two separate components, one for CONUS and one for Alaska.