### PR TITLE
Fix report map jank

### DIFF
--- a/webapp/components/Map.vue
+++ b/webapp/components/Map.vue
@@ -6,7 +6,6 @@ import {
   clearSegmentLayers,
 } from '~/utils/map'
 import { MapPhase, ALL_MAP_PARAMS } from '~/types/map'
-import waterLoaderUrl from '@/assets/water-loader.svg'
 
 const { $L, $config } = useNuxtApp()
 const route = useRoute()
@@ -581,12 +580,9 @@ onMounted(() => {
     >
       &larr;&nbsp;{{ backButtonLabel }}
     </button>
-    <div v-if="isLoadingPhase2" class="map-loading-overlay">
-      <img :src="waterLoaderUrl" class="map-loading-icon" alt="" />
-      <p class="mt-3 has-text-white is-size-3 is-bold">
-        Loading stream network&hellip;
-      </p>
-    </div>
+    <MapLoadingOverlay v-if="isLoadingPhase2">
+      Loading stream network&hellip;
+    </MapLoadingOverlay>
   </div>
 </template>
 
@@ -604,25 +600,7 @@ onMounted(() => {
   position: absolute;
   top: 0.75rem;
   left: 0.75rem;
-  // Above Leaflet panes (max ~700), below the loading overlay (1100).
+  // Above Leaflet panes (max ~700), below MapLoadingOverlay (1100).
   z-index: 1000;
-}
-
-.map-loading-overlay {
-  position: absolute;
-  inset: 0;
-  // Above Leaflet panes (max ~700) and controls (~1000).
-  z-index: 1100;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  background: rgba(128, 128, 128, 0.5);
-  pointer-events: all;
-}
-
-.map-loading-icon {
-  width: 6rem;
-  height: 6rem;
 }
 </style>

--- a/webapp/components/MapLoadingOverlay.vue
+++ b/webapp/components/MapLoadingOverlay.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import waterLoaderUrl from '@/assets/water-loader.svg'
+</script>
+
+<template>
+  <div class="map-loading-overlay">
+    <img :src="waterLoaderUrl" class="map-loading-icon" alt="" />
+    <p class="mt-3 has-text-white is-size-3 has-text-weight-semibold">
+      <slot />
+    </p>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+// Covers the nearest positioned ancestor: the element wrapping the map
+// must have position: relative.
+.map-loading-overlay {
+  position: absolute;
+  inset: 0;
+  // Above Leaflet panes (max ~700) and controls (~1000).
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(128, 128, 128, 0.5);
+  pointer-events: all;
+}
+
+.map-loading-icon {
+  width: 6rem;
+  height: 6rem;
+}
+</style>

--- a/webapp/components/Report/Map.vue
+++ b/webapp/components/Report/Map.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 const { $L } = useNuxtApp()
 import { useStreamSegmentStore } from '~/stores/streamSegment'
-import { fetchAndAddSegmentsByBounds } from '~/utils/map'
+import { fetchAndAddSegmentsByBounds, fetchSegmentById } from '~/utils/map'
+import waterLoaderUrl from '@/assets/water-loader.svg'
 const streamSegmentStore = useStreamSegmentStore()
 let { isLoading, segmentRegion, segmentId } = storeToRefs(streamSegmentStore)
 let map: any = null
+const mapReady = ref(false)
 
 // Set maxBounds to a large square around current map viewport.
 const setMapMaxBounds = () => {
@@ -20,34 +22,18 @@ const setMapMaxBounds = () => {
   map.setMaxBounds(paddedBounds)
 }
 
-const addSegment = async () => {
+const initializeMap = async () => {
   if (!segmentId.value) {
     const route = useRoute()
-    const id = computed(() => parseInt(route.params.segment))
-    segmentId.value = id.value
+    segmentId.value = parseInt(route.params.segment)
   }
 
-  if (isLoading.value) return
-
-  await fetchAndAddSegmentsByBounds({
-    map,
-    $L,
-    fitBounds: true,
-    mapType: 'report',
+  map = $L.map('report-map', {
+    scrollWheelZoom: false,
+    zoomControl: false,
+    doubleClickZoom: false,
+    zoomSnap: 0.1,
   })
-
-  setMapMaxBounds()
-}
-
-const initializeMap = () => {
-  map = $L
-    .map('report-map', {
-      scrollWheelZoom: false,
-      zoomControl: false,
-      doubleClickZoom: false,
-      zoomSnap: 0.1,
-    })
-    .setView([37.8, -96], 8)
 
   let maxZoom = segmentRegion.value === 'alaska' ? 12 : 13
 
@@ -60,7 +46,37 @@ const initializeMap = () => {
     }
   ).addTo(map)
 
-  addSegment()
+  // Fetch the selected segment before giving the map its first view, so the
+  // only tiles ever requested are for the segment's own location: setting a
+  // default view here and moving it after the segment arrived made the map
+  // visibly jump to the right place.
+  let segmentBounds: any = null
+  try {
+    const segmentData = await fetchSegmentById({ segmentId: segmentId.value })
+    segmentBounds = $L.geoJSON(segmentData).getBounds()
+  } catch (error) {
+    console.error('Error fetching selected segment:', error)
+  }
+
+  if (segmentBounds?.isValid()) {
+    map.fitBounds(segmentBounds, { padding: [50, 50] })
+  } else {
+    // Segment fetch failed or returned no geometry: show the whole region.
+    let regionCenter =
+      segmentRegion.value === 'alaska' ? [64.2, -152.0] : [37.8, -96]
+    map.setView(regionCenter, 4)
+  }
+
+  setMapMaxBounds()
+
+  await fetchAndAddSegmentsByBounds({
+    map,
+    $L,
+    fitBounds: false,
+    mapType: 'report',
+  })
+
+  mapReady.value = true
 
   map.on('moveend', function (e) {
     fetchAndAddSegmentsByBounds({
@@ -88,7 +104,37 @@ onMounted(() => {
   <p class="is-size-5 mb-2">
     🔴 Watershed outflow segments in the map below are shown in red.
   </p>
-  <div id="report-map" style="height: 400px" class="mb-6"></div>
+  <div class="mb-6">
+    <div id="report-map"></div>
+    <div v-if="!mapReady" class="report-map-loading-overlay">
+      <img :src="waterLoaderUrl" class="report-map-loading-icon" alt="" />
+      <p class="mt-3 has-text-white is-size-5 has-text-weight-semibold">
+        Loading map&hellip;
+      </p>
+    </div>
+  </div>
 </template>
 
-<style lang="scss"></style>
+<style lang="scss" scoped>
+#report-map {
+  height: 60vh;
+}
+
+.report-map-loading-overlay {
+  position: absolute;
+  inset: 0;
+  // Above Leaflet panes (max ~700) and controls (~1000).
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(128, 128, 128, 0.5);
+  pointer-events: all;
+}
+
+.report-map-loading-icon {
+  width: 4rem;
+  height: 4rem;
+}
+</style>

--- a/webapp/components/Report/Map.vue
+++ b/webapp/components/Report/Map.vue
@@ -2,7 +2,6 @@
 const { $L } = useNuxtApp()
 import { useStreamSegmentStore } from '~/stores/streamSegment'
 import { fetchAndAddSegmentsByBounds, fetchSegmentById } from '~/utils/map'
-import waterLoaderUrl from '@/assets/water-loader.svg'
 const streamSegmentStore = useStreamSegmentStore()
 let { isLoading, segmentRegion, segmentId } = storeToRefs(streamSegmentStore)
 let map: any = null
@@ -104,37 +103,18 @@ onMounted(() => {
   <p class="is-size-5 mb-2">
     🔴 Watershed outflow segments in the map below are shown in red.
   </p>
-  <div class="mb-6">
+  <div class="report-map-wrapper mb-6">
     <div id="report-map"></div>
-    <div v-if="!mapReady" class="report-map-loading-overlay">
-      <img :src="waterLoaderUrl" class="report-map-loading-icon" alt="" />
-      <p class="mt-3 has-text-white is-size-5 has-text-weight-semibold">
-        Loading map&hellip;
-      </p>
-    </div>
+    <MapLoadingOverlay v-if="!mapReady">Loading map&hellip;</MapLoadingOverlay>
   </div>
 </template>
 
 <style lang="scss" scoped>
+.report-map-wrapper {
+  position: relative;
+}
+
 #report-map {
   height: 60vh;
-}
-
-.report-map-loading-overlay {
-  position: absolute;
-  inset: 0;
-  // Above Leaflet panes (max ~700) and controls (~1000).
-  z-index: 1100;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  background: rgba(128, 128, 128, 0.5);
-  pointer-events: all;
-}
-
-.report-map-loading-icon {
-  width: 4rem;
-  height: 4rem;
 }
 </style>

--- a/webapp/components/Report/Map.vue
+++ b/webapp/components/Report/Map.vue
@@ -121,7 +121,8 @@ onMounted(() => {
 
 #report-map {
   height: 60vh;
-<style lang="scss">
+}
+
 .outflow-legend-swatch {
   display: inline-block;
   width: 0.8em;

--- a/webapp/utils/map.ts
+++ b/webapp/utils/map.ts
@@ -65,7 +65,6 @@ export const addSegmentsGeoJson = ({
   fitBounds = true,
   mapType = 'main',
   mapRegion = 'conus',
-  preload = false,
 }: {
   map: any
   $L: any
@@ -74,7 +73,6 @@ export const addSegmentsGeoJson = ({
   fitBounds?: boolean
   mapType?: 'main' | 'report'
   mapRegion?: 'conus' | 'alaska'
-  preload?: boolean
 }) => {
   const streamSegmentStore = useStreamSegmentStore()
   let { segmentRegion } = storeToRefs(streamSegmentStore)
@@ -98,11 +96,6 @@ export const addSegmentsGeoJson = ({
   let orderedSegments = selectedSegment
     ? [...otherSegments, selectedSegment]
     : otherSegments
-
-  let opacity = 1
-  if (preload) {
-    opacity = 0
-  }
 
   orderedSegments.forEach((feature: any) => {
     let isSelected = (selectedSegmentId &&
@@ -134,7 +127,6 @@ export const addSegmentsGeoJson = ({
         weight: lineWeight,
         color: segmentColor,
         interactive: interactive,
-        opacity: opacity,
       },
     })
 
@@ -155,7 +147,6 @@ export const addSegmentsGeoJson = ({
         color: segmentColor,
         fillColor: segmentColor,
         interactive: interactive,
-        opacity: opacity,
       })
       segmentParts = [line, handle]
     }
@@ -225,32 +216,33 @@ export const addSegmentsGeoJson = ({
       map.fitBounds(selectedSegmentLayer.getBounds(), { padding: [50, 50] })
     }
 
-    if (!preload) {
-      // Only add marker if one doesn't already exist.
-      let markerExists = false
-      map.eachLayer((layer: any) => {
-        if (layer instanceof $L.Marker) {
-          markerExists = true
-        }
-      })
-
-      if (!markerExists) {
-        let latlng = getHandleCoord(selectedSegment)
-        $L.marker(latlng).addTo(map)
+    // Only add marker if one doesn't already exist.
+    let markerExists = false
+    map.eachLayer((layer: any) => {
+      if (layer instanceof $L.Marker) {
+        markerExists = true
       }
+    })
+
+    if (!markerExists) {
+      let latlng = getHandleCoord(selectedSegment)
+      $L.marker(latlng).addTo(map)
     }
   }
 }
 
-// Builds the WFS request URL for all segments intersecting a lat/lng bounds.
-const segmentBboxUrl = (bounds: any, mapRegion: 'conus' | 'alaska') => {
+// Builds the WFS request base URL for a region's stream segment layer.
+const segmentLayerBaseUrl = (mapRegion: 'conus' | 'alaska') => {
   const { $config } = useNuxtApp()
   const wfsBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&outputFormat=application%2Fjson&srsName=EPSG:4326`
-  const segBaseUrl =
-    mapRegion === 'alaska'
-      ? `${wfsBaseUrl}&typeName=hydrology%3Aarctic_rivers_segments_joined_3338_simplified_v2`
-      : `${wfsBaseUrl}&typeName=hydrology%3Aseg_h8_outlet_stats_simplified_v2`
+  return mapRegion === 'alaska'
+    ? `${wfsBaseUrl}&typeName=hydrology%3Aarctic_rivers_segments_joined_3338_simplified_v2`
+    : `${wfsBaseUrl}&typeName=hydrology%3Aseg_h8_outlet_stats_simplified_v2`
+}
 
+// Builds the WFS request URL for all segments intersecting a lat/lng bounds.
+const segmentBboxUrl = (bounds: any, mapRegion: 'conus' | 'alaska') => {
+  const segBaseUrl = segmentLayerBaseUrl(mapRegion)
   const minLon = bounds.getWest()
   const maxLon = bounds.getEast()
   const minLat = bounds.getSouth()
@@ -284,6 +276,34 @@ export const fetchSegmentsForBounds = async ({
   return response.json()
 }
 
+// Fetches (but does not add) the GeoJSON for a single stream segment. Lets the
+// report map fit itself to the segment before its first view is set, so no
+// tiles or segments are ever requested for the wrong place.
+export const fetchSegmentById = async ({
+  segmentId,
+  region = 'conus',
+}: {
+  segmentId: number | string
+  region?: 'conus' | 'alaska'
+}) => {
+  const streamSegmentStore = useStreamSegmentStore()
+  const { segmentRegion } = storeToRefs(streamSegmentStore)
+  const mapRegion = segmentRegion.value || region
+
+  const idFilter =
+    mapRegion === 'alaska' ? `COMID=${segmentId}` : `seg_id_nat=${segmentId}`
+
+  const response = await fetch(
+    segmentLayerBaseUrl(mapRegion) + `&cql_filter=${idFilter}`
+  )
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch segment ${segmentId}: ${response.status} ${response.statusText}`
+    )
+  }
+  return response.json()
+}
+
 export const fetchAndAddSegmentsByBounds = ({
   map,
   $L,
@@ -297,104 +317,12 @@ export const fetchAndAddSegmentsByBounds = ({
   mapType?: 'main' | 'report'
   region?: 'conus' | 'alaska'
 }) => {
-  const { $config } = useNuxtApp()
   const streamSegmentStore = useStreamSegmentStore()
   let { segmentId, segmentRegion } = storeToRefs(streamSegmentStore)
 
   let mapRegion = segmentRegion.value || region
 
-  const wfsBaseUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&outputFormat=application%2Fjson&srsName=EPSG:4326`
-  const segBaseUrl =
-    mapRegion === 'alaska'
-      ? `${wfsBaseUrl}&typeName=hydrology%3Aarctic_rivers_segments_joined_3338_simplified_v2`
-      : `${wfsBaseUrl}&typeName=hydrology%3Aseg_h8_outlet_stats_simplified_v2`
-
-  if (segmentId.value) {
-    // Fetch only the selected segment first to determine map bounds.
-    // The selected segment will be added with an opacity of 0 until fitBounds is called.
-    // It will then be removed and added back to the map with full opacity along with all
-    // other viewport segments. This is "preload" mode.
-    let selectedSegUrl: string
-    if (mapRegion === 'alaska') {
-      selectedSegUrl = segBaseUrl + `&cql_filter=COMID=${segmentId.value}`
-    } else {
-      selectedSegUrl = segBaseUrl + `&cql_filter=seg_id_nat=${segmentId.value}`
-    }
-
-    return fetch(selectedSegUrl)
-      .then(response => {
-        if (!response.ok) {
-          throw new Error(
-            `Failed to fetch selected segment: ${response.status} ${response.statusText}`
-          )
-        }
-        return response.json()
-      })
-      .then(selectedData => {
-        // Add and fit bounds to the selected segment
-        addSegmentsGeoJson({
-          map,
-          $L,
-          data: selectedData,
-          selectedSegmentId: segmentId.value,
-          fitBounds,
-          mapType: mapType,
-          mapRegion: mapRegion,
-          preload: true,
-        })
-
-        // Map is now fit to bounds of selected segment. Now fetch everything in map viewport.
-        // No selected segment, so just fetch segments in current viewport.
-        const bounds = map.getBounds()
-        const minLon = bounds.getWest()
-        const maxLon = bounds.getEast()
-        const minLat = bounds.getSouth()
-        const maxLat = bounds.getNorth()
-
-        const segUrl =
-          segBaseUrl +
-          `&cql_filter=BBOX(the_geom,${minLon},${minLat},${maxLon},${maxLat},'EPSG:4326')`
-
-        return fetch(segUrl)
-          .then(response => {
-            if (!response.ok) {
-              throw new Error(
-                `Failed to fetch segment data: ${response.status} ${response.statusText}`
-              )
-            }
-            return response.json()
-          })
-          .then(data => {
-            clearSegmentLayers(map)
-            // Add all viewport segments (including selected)
-            addSegmentsGeoJson({
-              map,
-              $L,
-              data: data,
-              selectedSegmentId: segmentId.value,
-              fitBounds: fitBounds,
-              mapType: mapType,
-              mapRegion: mapRegion,
-            })
-          })
-      })
-      .catch(error => {
-        console.error('Error fetching segment data:', error)
-      })
-  }
-
-  // No selected segment, so just fetch segments in current viewport.
-  const bounds = map.getBounds()
-  const minLon = bounds.getWest()
-  const maxLon = bounds.getEast()
-  const minLat = bounds.getSouth()
-  const maxLat = bounds.getNorth()
-
-  const segUrl =
-    segBaseUrl +
-    `&cql_filter=BBOX(the_geom,${minLon},${minLat},${maxLon},${maxLat},'EPSG:4326')`
-
-  return fetch(segUrl)
+  return fetch(segmentBboxUrl(map.getBounds(), mapRegion))
     .then(response => {
       if (!response.ok) {
         throw new Error(
@@ -405,11 +333,13 @@ export const fetchAndAddSegmentsByBounds = ({
     })
     .then(data => {
       clearSegmentLayers(map)
+      // The selected segment (set only on report pages; null on the main map)
+      // gets its selected styling whenever the viewport includes it.
       addSegmentsGeoJson({
         map,
         $L,
         data,
-        selectedSegmentId: null,
+        selectedSegmentId: segmentId.value,
         fitBounds,
         mapType: mapType,
         mapRegion: mapRegion,


### PR DESCRIPTION
Closes #224 

Testing: for both Alaska and CONUS, ensure that the map loading overlay displays as expected when navigating into Phase 2 of the map navigation, and on the report pages.

[AI Generated summary / OK]
The report map was created at a hardcoded CONUS-centered view, so it
briefly showed the wrong place (or nothing) and then jumped to the
stream segment once its geometry loaded — especially jarring for
Alaska segments.

- Fetch the selected segment's geometry before giving the map its
  first view, so the map is created already fit to the segment and
  tiles are only ever requested for the right location; fall back to
  a whole-region view if the segment fetch fails
- Show a loading overlay until tiles and segments are in place
- Remove the now-unneeded "preload" double-fetch path from
  fetchAndAddSegmentsByBounds; pass the selected segment id through
  the shared path so it keeps its styling when panning, and extract
  the duplicated WFS URL building into segmentLayerBaseUrl
- Extract the water-loader overlay shared by the main and report maps
  into a MapLoadingOverlay component


