### PR TITLE
Change text to "not available" for null stat table values, with explanation in the corresponding table footer

### DIFF
--- a/webapp/components/StatValue.vue
+++ b/webapp/components/StatValue.vue
@@ -24,7 +24,7 @@ const past = computed<number | null>(() => {
 
 const formattedValue = computed(() => {
   if (value.value === null) {
-    return 'N/A'
+    return 'not available<sup>*</sup>'
   }
   return fnc(value.value)
 })
@@ -32,7 +32,7 @@ const formattedValue = computed(() => {
 
 <template>
   <span>
-    <span class="number">{{ formattedValue }}</span>
+    <span class="number" v-html="formattedValue" />
     <Diff
       v-if="past !== null && value !== null"
       :past="past"

--- a/webapp/components/StatsTable/Alaska.vue
+++ b/webapp/components/StatsTable/Alaska.vue
@@ -70,7 +70,7 @@ const hasNullValues = computed(() => {
       </tbody>
       <tfoot v-if="hasNullValues">
         <tr>
-          <td colspan="5" v-html="nullValueFooter"></td>
+          <td colspan="5">{{ nullValueFooter }}</td>
         </tr>
       </tfoot>
     </table>

--- a/webapp/components/StatsTable/Alaska.vue
+++ b/webapp/components/StatsTable/Alaska.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { scenarioFullNames } from '~/types/modelsScenarios'
 import { fnc, roundSigFig } from '~/utils/general'
+import { nullValueFooter } from '~/utils/table'
 import { computed } from 'vue'
 
 import { statistics } from '~/types/statsVars'
@@ -16,6 +17,18 @@ var statsInCategory = $_.filter(statistics, {
 
 const tableCaptionHtml = computed(() => {
   return props.tableTitle + ', Mid-Century (2034&ndash;2065)'
+})
+
+const hasNullValues = computed(() => {
+  if (!statsData.value) return false
+  const checkNull = (val: any) => val === null || val === undefined
+  return statsInCategory.some((stat: any) => {
+    const values = [
+      statsData.value['historical']['1990-2021'][stat.id],
+      statsData.value['projected']['2034-2065'][stat.id]?.median,
+    ]
+    return values.some(checkNull)
+  })
 })
 </script>
 
@@ -77,6 +90,11 @@ const tableCaptionHtml = computed(() => {
           </td>
         </tr>
       </tbody>
+      <tfoot v-if="hasNullValues">
+        <tr>
+          <td colspan="5" v-html="nullValueFooter"></td>
+        </tr>
+      </tfoot>
     </table>
   </div>
 </template>

--- a/webapp/components/StatsTable/Alaska.vue
+++ b/webapp/components/StatsTable/Alaska.vue
@@ -57,35 +57,13 @@ const hasNullValues = computed(() => {
           <td v-html="stat.description"></td>
           <td v-html="stat.units_short"></td>
           <td>
-            <span class="number">{{
-              fnc(
-                roundSigFig(
-                  Number(statsData['historical']['1990-2021'][stat.id])
-                )
-              )
-            }}</span>
+            <StatValue :value="statsData['historical']['1990-2021'][stat.id]" />
           </td>
           <td>
-            <span class="number">
-              {{
-                fnc(
-                  roundSigFig(
-                    Number(statsData['projected']['2034-2065'][stat.id].median)
-                  )
-                )
-              }}
-            </span>
-            <Diff
-              :past="
-                roundSigFig(
-                  Number(statsData['historical']['1990-2021'][stat.id])
-                )
-              "
-              :future="
-                roundSigFig(
-                  Number(statsData['projected']['2034-2065'][stat.id].median)
-                )
-              "
+            <StatValue
+              :value="statsData['projected']['2034-2065'][stat.id].median"
+              :past="statsData['historical']['1990-2021'][stat.id]"
+              :statId="stat.id"
             />
           </td>
         </tr>

--- a/webapp/components/StatsTable/Conus.vue
+++ b/webapp/components/StatsTable/Conus.vue
@@ -127,7 +127,7 @@ const hasNullValues = computed(() => {
       </tbody>
       <tfoot v-if="hasNullValues">
         <tr>
-          <td colspan="5" v-html="nullValueFooter"></td>
+          <td colspan="6">{{ nullValueFooter }}</td>
         </tr>
       </tfoot>
     </table>

--- a/webapp/components/StatsTable/Conus.vue
+++ b/webapp/components/StatsTable/Conus.vue
@@ -79,7 +79,7 @@ const hasNullValues = computed(() => {
       </tbody>
       <tfoot v-if="hasNullValues">
         <tr>
-          <td colspan="5" v-html="nullValueFooter"></td>
+          <td colspan="5">{{ nullValueFooter }}</td>
         </tr>
       </tfoot>
     </table>

--- a/webapp/components/StatsTable/Conus.vue
+++ b/webapp/components/StatsTable/Conus.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { eraFullNamesHtml, scenarioFullNames } from '~/types/modelsScenarios'
+import { nullValueFooter } from '~/utils/table'
 import { computed } from 'vue'
 
 import { statistics } from '~/types/statsVars'
@@ -15,6 +16,26 @@ var statsInCategory = $_.filter(statistics, {
 
 const tableCaptionHtml = computed(() => {
   return props.tableTitle + ', ' + eraFullNamesHtml[appEra.value]
+})
+
+const hasNullValues = computed(() => {
+  if (!props.streamStats) return false
+  const checkNull = (val: any) => val === null || val === undefined
+  return statsInCategory.some((stat: any) => {
+    const values = [
+      props.streamStats['historical']['1976-2005'][stat.id],
+      ...(appContext.value === 'mid'
+        ? [
+            props.streamStats['projected'][appEra.value]['rcp60'][stat.id]
+              ?.median,
+          ]
+        : [
+            props.streamStats['projected'][appEra.value]['rcp45'][stat.id]?.min,
+            props.streamStats['projected'][appEra.value]['rcp85'][stat.id]?.max,
+          ]),
+    ]
+    return values.some(checkNull)
+  })
 })
 </script>
 
@@ -56,6 +77,11 @@ const tableCaptionHtml = computed(() => {
           </td>
         </tr>
       </tbody>
+      <tfoot v-if="hasNullValues">
+        <tr>
+          <td colspan="5" v-html="nullValueFooter"></td>
+        </tr>
+      </tfoot>
     </table>
     <table class="table" v-if="appContext == 'extremes'">
       <caption class="mb-4" v-html="tableCaptionHtml"></caption>
@@ -99,6 +125,11 @@ const tableCaptionHtml = computed(() => {
           </td>
         </tr>
       </tbody>
+      <tfoot v-if="hasNullValues">
+        <tr>
+          <td colspan="5" v-html="nullValueFooter"></td>
+        </tr>
+      </tfoot>
     </table>
   </div>
 </template>

--- a/webapp/utils/table.ts
+++ b/webapp/utils/table.ts
@@ -1,0 +1,2 @@
+export const nullValueFooter =
+  '*Value is either not available from the source dataset or the calculation is undefined.'


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/191

This PR changes the text for null stat table values from "N/A" to "not available*", with an explanation in the table footer. The `tfoot` explanation is only included if a null value is found, which is rare.

Since our existing logic to detect null values is table-cell-specific and agnostic of which table if applies to, separate (Claude-generated)`hasNullValues` functions were added to both the CONUS and Alaska StatTable components that scans for null values to determine if the `tfoot` explanation is needed, per table.

I also discovered that the Alaska StatTable component was still displaying table cell values the old way, not using the `StatValue` wrapper like CONUS. This has been fixed.

For testing, here is a CONUS stream segment with a null value: http://localhost:3000/conus/stream/13369 Observe the new "not available*" text and footer explanation for only the relevant table.

I haven't been able to find an Alaska stream segment with null values (although I'm sure they exist). So, to test the Alaska stats tables, I set `export HYDROVIZ_USE_STATIC_FIXTURES=true` and set a couple values in `alaska_output_example.json` to null.