### PR TITLE
Add ability to search by USGS gage ID

### DIFF
--- a/webapp/components/Intro.vue
+++ b/webapp/components/Intro.vue
@@ -18,7 +18,8 @@
         </p>
 
         <p class="is-size-4 mt-4">
-          Search HUC-8 watersheds by name or ID. <Search />
+          Search HUC-8 watersheds by name or ID, or find a stream by its USGS
+          gage ID. <Search />
         </p>
       </header>
     </div>

--- a/webapp/components/Search.vue
+++ b/webapp/components/Search.vue
@@ -28,6 +28,8 @@ onMounted(() => {
               fetch(alaskaGageUrl).then(res => res.json()),
             ])
 
+          // 'category' is a stable key the selection handler routes on;
+          // 'label' is the display text shown in the dropdown.
           if (hucRes && Array.isArray(hucRes.features)) {
             hucRes.features.forEach((feature: any) => {
               let hucId = feature.properties.huc8
@@ -36,6 +38,7 @@ onMounted(() => {
                 name: name,
                 id: hucId,
                 category: 'huc',
+                label: 'huc',
                 region: 'conus',
               })
             })
@@ -49,6 +52,7 @@ onMounted(() => {
                 name: name,
                 id: hucId,
                 category: 'huc',
+                label: 'huc',
                 region: 'alaska',
               })
             })
@@ -63,7 +67,8 @@ onMounted(() => {
               items.push({
                 name: name,
                 id: segId,
-                category: 'gage ID',
+                category: 'gage',
+                label: 'gage ID',
                 region: 'conus',
               })
             })
@@ -78,7 +83,8 @@ onMounted(() => {
               items.push({
                 name: name,
                 id: segId,
-                category: 'gage ID',
+                category: 'gage',
+                label: 'gage ID',
                 region: 'alaska',
               })
             })
@@ -98,7 +104,7 @@ onMounted(() => {
       element: (element: HTMLElement, match: any) => {
         let item = match.value
         element.innerHTML =
-          item.name + '<span class="category">' + item.category + '</span>'
+          item.name + '<span class="category">' + item.label + '</span>'
       },
     },
     threshold: 3,

--- a/webapp/components/Search.vue
+++ b/webapp/components/Search.vue
@@ -63,7 +63,7 @@ onMounted(() => {
               items.push({
                 name: name,
                 id: segId,
-                category: 'gage',
+                category: 'gage ID',
                 region: 'conus',
               })
             })
@@ -78,7 +78,7 @@ onMounted(() => {
               items.push({
                 name: name,
                 id: segId,
-                category: 'gage',
+                category: 'gage ID',
                 region: 'alaska',
               })
             })
@@ -152,17 +152,8 @@ onMounted(() => {
 
 <style lang="scss" scoped>
 #search {
-  border: 1px solid rgba(33, 33, 33, 0.2);
-  border-radius: 4px;
-  color: #747474;
-  font-size: 1rem;
-  height: 40px;
-  outline: none;
-  padding-left: 10px;
-  max-width: 30rem;
-  background: none;
+  width: 35rem;
 }
-
 :deep(.autoComplete_wrapper ul) {
   z-index: 1000;
 }

--- a/webapp/components/Search.vue
+++ b/webapp/components/Search.vue
@@ -5,21 +5,28 @@ const inputValue = ref('')
 onMounted(() => {
   let autoCompleteConfig = {
     selector: '#search',
-    placeHolder: 'Search for a HUC-8 watershed',
+    placeHolder: 'Search for a HUC-8 watershed or USGS gage ID',
     data: {
       src: async (query: string) => {
         // Escape single quotes for safe use inside CQL string literals
         const safeQuery = query.replace(/'/g, "''")
         const hucUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Ahuc8_conus_stats_simplified&outputFormat=application%2Fjson&srsName=EPSG:4326&propertyName=huc8,name&cql_filter=name%20ILIKE%20%27%25${safeQuery}%25%27%20OR%20huc8%20LIKE%20%27%25${safeQuery}%25%27`
         const alaskaHucUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Aarctic_rivers_watersheds_stats_simplified_v2&outputFormat=application%2Fjson&srsName=EPSG:4326&propertyName=ID_2,Name&cql_filter=Name%20ILIKE%20%27%25${safeQuery}%25%27%20OR%20ID_2%20LIKE%20%27%25${safeQuery}%25%27`
+        // Ungaged CONUS segments have a GAGE_ID of 'NA' rather than an
+        // empty string, so exclude those from gage ID matches.
+        const gageUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Aseg_h8_outlet_stats_simplified_v2&outputFormat=application%2Fjson&srsName=EPSG:4326&propertyName=seg_id_nat,GNIS_NAME,GAGE_ID&cql_filter=GAGE_ID%20ILIKE%20%27%25${safeQuery}%25%27%20AND%20GAGE_ID%20%3C%3E%20%27NA%27`
+        const alaskaGageUrl = `${$config.public.geoserverUrl}/hydrology/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology%3Aarctic_rivers_segments_joined_3338_simplified_v2&outputFormat=application%2Fjson&srsName=EPSG:4326&propertyName=COMID,Name,Gage_ID&cql_filter=Gage_ID%20ILIKE%20%27%25${safeQuery}%25%27`
 
         let items: any[] = []
 
         try {
-          const [hucRes, alaskaHucRes] = await Promise.all([
-            fetch(hucUrl).then(res => res.json()),
-            fetch(alaskaHucUrl).then(res => res.json()),
-          ])
+          const [hucRes, alaskaHucRes, gageRes, alaskaGageRes] =
+            await Promise.all([
+              fetch(hucUrl).then(res => res.json()),
+              fetch(alaskaHucUrl).then(res => res.json()),
+              fetch(gageUrl).then(res => res.json()),
+              fetch(alaskaGageUrl).then(res => res.json()),
+            ])
 
           if (hucRes && Array.isArray(hucRes.features)) {
             hucRes.features.forEach((feature: any) => {
@@ -47,7 +54,37 @@ onMounted(() => {
             })
           }
 
-          items = $_.sortBy(items, ['name'])
+          if (gageRes && Array.isArray(gageRes.features)) {
+            gageRes.features.forEach((feature: any) => {
+              let segId = feature.properties.seg_id_nat
+              let gageId = feature.properties.GAGE_ID
+              let streamName = feature.properties.GNIS_NAME
+              let name = streamName ? `${streamName} (${gageId})` : gageId
+              items.push({
+                name: name,
+                id: segId,
+                category: 'gage',
+                region: 'conus',
+              })
+            })
+          }
+
+          if (alaskaGageRes && Array.isArray(alaskaGageRes.features)) {
+            alaskaGageRes.features.forEach((feature: any) => {
+              let segId = feature.properties.COMID
+              let gageId = feature.properties.Gage_ID
+              let streamName = feature.properties.Name
+              let name = streamName ? `${streamName} (${gageId})` : gageId
+              items.push({
+                name: name,
+                id: segId,
+                category: 'gage',
+                region: 'alaska',
+              })
+            })
+          }
+
+          items = $_.sortBy(items, ['category', 'name'])
 
           return items
         } catch (error) {
@@ -56,6 +93,13 @@ onMounted(() => {
         }
       },
       keys: ['name'],
+    },
+    resultItem: {
+      element: (element: HTMLElement, match: any) => {
+        let item = match.value
+        element.innerHTML =
+          item.name + '<span class="category">' + item.category + '</span>'
+      },
     },
     threshold: 3,
     debounce: 200,
@@ -71,9 +115,14 @@ onMounted(() => {
       id: id,
       name: selection.name,
       region: selection.region,
+      category: selection.category,
     })
 
-    if (selection.region === 'conus') {
+    if (selection.category === 'gage') {
+      const routePrefix =
+        selection.region === 'alaska' ? '/alaska/stream' : '/conus/stream'
+      navigateTo(routePrefix + '/' + id)
+    } else if (selection.region === 'conus') {
       navigateTo({
         path: '/',
         query: { cp: 2, chuc: id },
@@ -91,8 +140,14 @@ onMounted(() => {
 </script>
 
 <template>
-  <label class="label is-sr-only" for="search">Search by HUC-8 ID</label>
-  <input id="search" v-model="inputValue" class="input" />
+  <!-- The root div gives the runtime-created .autoComplete_wrapper a scoped
+       ancestor so the :deep() dropdown styles below can match. -->
+  <div>
+    <label class="label is-sr-only" for="search"
+      >Search by HUC-8 ID or USGS gage ID</label
+    >
+    <input id="search" v-model="inputValue" class="input" />
+  </div>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
Closes #266

Testing:
 - Enter 12161000 in the box, should get you a stream segment in CONUS
 - Test the navigation to/fro the report page
 - Enter 15896 in the box, go to the stream segment in Alaska
 - Do a mixed query (1771) to see both HUC/gage IDs in the results

Rough edges (tickets for later?)
 - Pasting doesn't trigger the search
 - Maybe people prefix their gage ID with `USGS-` ? If so that won't work.
 - Canada works (search for 09FD003) but we don't have the best story around that

[AI generated below]
Extends the home page search to query both region segment layers by gage ID, alongside the existing HUC-8 queries. Selecting a gage result navigates directly to that stream's report page. Restores the category label on autocomplete results (and re-scopes the dropdown styles so it renders) to distinguish gage matches from watershed matches.

