### PR TITLE
Update stats tables and their intro text to show medians for "extremes" mode

### DIFF
--- a/webapp/components/Report/Conus.vue
+++ b/webapp/components/Report/Conus.vue
@@ -156,14 +156,11 @@ onUnmounted(() => {
             model projections in the CMIP5 family of datasets.
           </p>
           <p v-if="appContext == 'extremes'">
-            The projected values in the table below show the extreme values
-            across two climate scenarios for 13 climate models. The values in
-            the &lsquo;Minimum, {{ scenarioFullNames.rcp45 }}&rsquo; column are
-            the minimum values across all 13 climate models for the
-            {{ scenarioFullNames.rcp45 }} scenario, and the values in the
-            &lsquo;Maximum, {{ scenarioFullNames.rcp85 }}&rsquo; column are the
-            maximum values across all 13 climate models for the
-            {{ scenarioFullNames.rcp85 }} scenario.
+            The projected values in the tables below show the median values
+            across the {{ scenarioFullNames.rcp45 }} and
+            {{ scenarioFullNames.rcp85 }} climate scenarios for 13 climate
+            models. For each scenario, these values represent the median
+            projection within the CMIP5 family of datasets.
           </p>
         </div>
         <StatsTable

--- a/webapp/components/StatsTable/Conus.vue
+++ b/webapp/components/StatsTable/Conus.vue
@@ -30,8 +30,10 @@ const hasNullValues = computed(() => {
               ?.median,
           ]
         : [
-            props.streamStats['projected'][appEra.value]['rcp45'][stat.id]?.min,
-            props.streamStats['projected'][appEra.value]['rcp85'][stat.id]?.max,
+            props.streamStats['projected'][appEra.value]['rcp45'][stat.id]
+              ?.median,
+            props.streamStats['projected'][appEra.value]['rcp85'][stat.id]
+              ?.median,
           ]),
     ]
     return values.some(checkNull)
@@ -111,14 +113,14 @@ const hasNullValues = computed(() => {
           </td>
           <td>
             <StatValue
-              :value="streamStats['projected'][appEra]['rcp45'][stat.id].min"
+              :value="streamStats['projected'][appEra]['rcp45'][stat.id].median"
               :past="streamStats['historical']['1976-2005'][stat.id]"
               :statId="stat.id"
             />
           </td>
           <td>
             <StatValue
-              :value="streamStats['projected'][appEra]['rcp85'][stat.id].max"
+              :value="streamStats['projected'][appEra]['rcp85'][stat.id].median"
               :past="streamStats['historical']['1976-2005'][stat.id]"
               :statId="stat.id"
             />


### PR DESCRIPTION
Closes #269

This PR updates the stats tables for CONUS "extremes" mode to show median values, not min/max, to agree with the column headers. It also updates the intro text above the stats tables to reflect this.

To test, pick a CONUS segment, switch to "extremes" mode and verify that the values are less extreme (i.e., the median) vs. the current S3 dev version of the website.