### PR TITLE
Add a beta warning banner to every page of the webapp

### DIFF
--- a/webapp/components/BetaWarning.vue
+++ b/webapp/components/BetaWarning.vue
@@ -1,0 +1,19 @@
+<template>
+  <section class="section message is-warning mb-0 pb-3">
+    <div class="container">
+      <div class="message-header">
+        <p>This is a public beta test of this tool</p>
+      </div>
+      <div class="message-body">
+        Thanks for checking out this tool! Right now, this is a public beta,
+        which means that we&rsquo;re still gathering feedback, testing the data
+        outputs and fixing bugs. We&rsquo;d love to hear your feedback! Email us
+        at
+        <a href="mailto:uaf-snap-data-tools@alaska.edu"
+          >uaf&ndash;snap&ndash;data&ndash;tools@alaska.edu</a
+        >
+        if you encounter a problem.
+      </div>
+    </div>
+  </section>
+</template>

--- a/webapp/components/BetaWarning.vue
+++ b/webapp/components/BetaWarning.vue
@@ -10,7 +10,7 @@
         outputs and fixing bugs. We&rsquo;d love to hear your feedback! Email us
         at
         <a href="mailto:uaf-snap-data-tools@alaska.edu"
-          >uaf&ndash;snap&ndash;data&ndash;tools@alaska.edu</a
+          >uaf-snap-data-tools@alaska.edu</a
         >
         if you encounter a problem.
       </div>

--- a/webapp/components/BetaWarning.vue
+++ b/webapp/components/BetaWarning.vue
@@ -1,18 +1,14 @@
 <template>
   <section class="section message is-warning mb-0 pb-3">
     <div class="container">
-      <div class="message-header">
-        <p>This is a public beta test of this tool</p>
-      </div>
-      <div class="message-body">
-        Thanks for checking out this tool! Right now, this is a public beta,
-        which means that we&rsquo;re still gathering feedback, testing the data
-        outputs and fixing bugs. We&rsquo;d love to hear your feedback! Email us
-        at
+      <div class="message-body is-size-5">
+        Thanks for checking out this tool! Right now,
+        <strong>this is a public beta test</strong>, which means that
+        we&rsquo;re still gathering feedback, testing the data outputs and
+        fixing bugs. We&rsquo;d love to hear your thoughts! Email us at
         <a href="mailto:uaf-snap-data-tools@alaska.edu"
           >uaf-snap-data-tools@alaska.edu</a
-        >
-        if you encounter a problem.
+        >.
       </div>
     </div>
   </section>

--- a/webapp/layouts/default.vue
+++ b/webapp/layouts/default.vue
@@ -1,5 +1,6 @@
 <template>
   <NavBar />
+  <BetaWarning />
   <NuxtRouteAnnouncer />
   <NuxtPage />
   <Footer />


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/271

This PR adds a beta warning banner to every page of the webapp, recycling some text we'd used for previous beta banners on other webapps.