### PR TITLE
Update placeholder domain for Umami with production domain

### DIFF
--- a/webapp/nuxt.config.ts
+++ b/webapp/nuxt.config.ts
@@ -111,7 +111,7 @@ export default defineNuxtConfig({
           src: 'https://umami.snap.uaf.edu/script.js',
           'data-website-id': 'a5a8e5a7-d390-4919-9502-827c2e1f1ac2',
           // Only track visits on the production domain, not development.
-          'data-domains': 'hydroviz.org',
+          'data-domains': 'futurehydrology.org',
           'data-do-not-track': 'true',
           async: 'true',
           defer: 'true',


### PR DESCRIPTION
This PR simply updates our placeholder domain (`hydroviz.org`) with our new production domain (`futurehydrology.org`) for Umami domain enforcement. I'm going to self-merge this because it's a trivial change. I've also updated the domain in the Umami web interface settings.