### PR TITLE
Make stream segment colors consistent between front vs. report maps

### DIFF
--- a/webapp/utils/map.ts
+++ b/webapp/utils/map.ts
@@ -1,34 +1,32 @@
 import { useStreamSegmentStore } from '~/stores/streamSegment'
 
-// Outflow (outlet) segments are always drawn in the same red, #ff6100
-// (oklch(0.7066 0.2256 41.22)), on both the main and report maps so the
-// "outflow segments are shown in red" text above each map holds true.
-// Exported so that text can show a legend swatch in the same color.
 export const outletRed = '#ff6100'
+export const regularBlue = '#7777ff'
+export const highlightYellow = '#ffff00'
 
 const segmentColors: Record<string, any> = {
   main: {
     selected: {
-      outlet: '#ffff00',
-      regular: '#ffff00',
-      hover: '#ffff00',
+      outlet: highlightYellow,
+      regular: highlightYellow,
+      hover: highlightYellow,
     },
     unselected: {
       outlet: outletRed,
-      regular: '#0000ff',
-      hover: '#ffff00',
+      regular: regularBlue,
+      hover: highlightYellow,
     },
   },
   report: {
     selected: {
       outlet: outletRed,
-      regular: '#0000ff',
-      hover: '#ffff00',
+      regular: regularBlue,
+      hover: highlightYellow,
     },
     unselected: {
       outlet: outletRed,
-      regular: '#7777ff',
-      hover: '#ffff00',
+      regular: regularBlue,
+      hover: highlightYellow,
     },
   },
 }

--- a/webapp/utils/map.ts
+++ b/webapp/utils/map.ts
@@ -1,7 +1,7 @@
 import { useStreamSegmentStore } from '~/stores/streamSegment'
 
 export const outletRed = '#ff6100'
-export const regularBlue = '#7777ff'
+export const regularBlue = '#0047ab'
 export const highlightYellow = '#ffff00'
 
 const segmentColors: Record<string, any> = {


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/209

This PR updates the stream segment colors so that they are the same between front & report page maps. This means that:

- the front page maps use the lighter, more pastel versions of red/orange and blue
- the report page map uses the lighter/pastel version of blue for the selected stream segment

I also removed a Claude-generated comment that felt a little too obvious/extra rather than making it even longer. Let me know if you disagree with this!