### PR TITLE
Add Playwright end-to-end smoke tests

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -9,6 +9,10 @@ dist
 # Node dependencies
 node_modules
 
+# Playwright outputs
+test-results
+playwright-report
+
 # Logs
 logs
 *.log

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -27,12 +27,12 @@ npm run dev
 ## Testing
 
 End-to-end smoke tests run with [Playwright](https://playwright.dev/) against
-Chromium and Firefox. The tests mock all external services (the hydroviz data
-API, GeoServer, and basemap tiles) via `page.route`, so they are deterministic
-and run offline — no API or `HYDROVIZ_USE_STATIC_FIXTURES` setup is needed.
-Report-page tests are served the fixture JSON from `assets/fixtures/`, which is
-the same for every segment id, so tests assert on page structure rather than
-data values.
+Chromium and Firefox. By default, the tests mock all external services (the
+hydroviz data API, GeoServer, and basemap tiles) via `page.route`, so they are
+deterministic and run offline — no API or `HYDROVIZ_USE_STATIC_FIXTURES` setup
+is needed. Report-page tests are served the fixture JSON from
+`assets/fixtures/`, which is the same for every segment id, so tests assert on
+page structure rather than data values.
 
 One-time setup (downloads the test browsers):
 
@@ -52,6 +52,29 @@ Run with the interactive Playwright UI:
 ```
 npm run test:e2e:ui
 ```
+
+### Live mode
+
+The same tests can run against the real external services (Data API,
+GeoServer, basemap tiles) instead of mocks — useful for verifying that the
+app and its external dependencies actually work together. Live mode is
+slower and depends on service availability, so it is opt-in.
+
+Against a local dev server, with real external services:
+
+```
+HYDROVIZ_E2E_LIVE=true npm run test:e2e
+```
+
+Against a deployed site (implies live mode; no local dev server is started):
+
+```
+HYDROVIZ_E2E_BASE_URL=https://example.com npm run test:e2e
+```
+
+The API-failure test still forces a 500 via request interception in live
+mode, since it tests how the app handles an outage rather than whether the
+service is up.
 
 Tests live in `tests/e2e/`; shared request mocks are in `tests/e2e/helpers.ts`.
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -24,6 +24,37 @@ cd webapp
 npm run dev
 ```
 
+## Testing
+
+End-to-end smoke tests run with [Playwright](https://playwright.dev/) against
+Chromium and Firefox. The tests mock all external services (the hydroviz data
+API, GeoServer, and basemap tiles) via `page.route`, so they are deterministic
+and run offline — no API or `HYDROVIZ_USE_STATIC_FIXTURES` setup is needed.
+Report-page tests are served the fixture JSON from `assets/fixtures/`, which is
+the same for every segment id, so tests assert on page structure rather than
+data values.
+
+One-time setup (downloads the test browsers):
+
+```
+npx playwright install chromium firefox
+```
+
+Run the suite (starts its own dev server on port 3000, or reuses one already
+running):
+
+```
+npm run test:e2e
+```
+
+Run with the interactive Playwright UI:
+
+```
+npm run test:e2e:ui
+```
+
+Tests live in `tests/e2e/`; shared request mocks are in `tests/e2e/helpers.ts`.
+
 ## Production
 
 This app is built as a fully static single-page app (`ssr: false` in

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -19,6 +19,7 @@
         "vue-router": "latest"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.0",
         "@types/leaflet": "^1.9.14",
         "prettier": "^3.3.3",
         "sass": "^1.80.6"
@@ -2831,6 +2832,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@plotly/d3": {
@@ -13174,6 +13191,53 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plotly.js": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,7 +10,9 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@pinia/nuxt": "^0.11.3",
@@ -25,6 +27,7 @@
     "vue-router": "latest"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.0",
     "@types/leaflet": "^1.9.14",
     "prettier": "^3.3.3",
     "sass": "^1.80.6"

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// End-to-end smoke tests. All external services (hydroviz data API,
+// GeoServer, basemap tiles) are mocked per-test via page.route — see
+// tests/e2e/helpers.ts — so the suite is deterministic and runs offline.
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['list'], ['html']] : 'list',
+  // Nuxt dev compiles routes on demand, so first paint of a heavy report
+  // page (Plotly) can exceed the 5s default.
+  expect: { timeout: 15_000 },
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,19 +1,31 @@
 import { defineConfig, devices } from '@playwright/test'
 
-// End-to-end smoke tests. All external services (hydroviz data API,
-// GeoServer, basemap tiles) are mocked per-test via page.route — see
+// End-to-end smoke tests. By default, all external services (hydroviz data
+// API, GeoServer, basemap tiles) are mocked per-test via page.route — see
 // tests/e2e/helpers.ts — so the suite is deterministic and runs offline.
+//
+// Live mode runs the same tests against the real external services:
+//   HYDROVIZ_E2E_LIVE=true npm run test:e2e
+// To also target a deployed site instead of the local dev server (implies
+// live mode):
+//   HYDROVIZ_E2E_BASE_URL=https://example.com npm run test:e2e
+const deployedBaseUrl = process.env.HYDROVIZ_E2E_BASE_URL
+const liveMode = process.env.HYDROVIZ_E2E_LIVE === 'true' || !!deployedBaseUrl
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? [['list'], ['html']] : 'list',
-  // Nuxt dev compiles routes on demand, so first paint of a heavy report
-  // page (Plotly) can exceed the 5s default.
-  expect: { timeout: 15_000 },
+  // The live data API can take a minute per report request, so live mode
+  // needs far longer timeouts. In mock mode, Nuxt dev compiles routes on
+  // demand, so first paint of a heavy report page (Plotly) can still exceed
+  // the 5s expect default.
+  timeout: liveMode ? 180_000 : 30_000,
+  expect: { timeout: liveMode ? 90_000 : 15_000 },
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: deployedBaseUrl || 'http://localhost:3000',
     trace: 'on-first-retry',
   },
   projects: [
@@ -26,10 +38,13 @@ export default defineConfig({
       use: { ...devices['Desktop Firefox'] },
     },
   ],
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  // When targeting a deployed site, don't start a local dev server.
+  webServer: deployedBaseUrl
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
 })

--- a/webapp/tests/e2e/helpers.ts
+++ b/webapp/tests/e2e/helpers.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { Page } from '@playwright/test'
+
+// The dev server runs without HYDROVIZ_USE_STATIC_FIXTURES so that data API
+// requests actually hit the network, where these helpers intercept them.
+// Happy-path tests are fulfilled with the same fixture JSON the app bundles
+// in assets/fixtures/; the failure test fulfills with a 500 instead. This
+// keeps every test deterministic and offline while still exercising the real
+// fetch/loading/error code paths in stores/streamSegment.ts.
+
+const fixturePath = (name: string) =>
+  path.join(process.cwd(), 'assets', 'fixtures', name)
+
+const emptyFeatureCollection = JSON.stringify({
+  type: 'FeatureCollection',
+  features: [],
+})
+
+// 1x1 transparent PNG, served in place of map tiles.
+const transparentPng = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+// Serve the bundled example fixture for hydroviz data API requests so report
+// pages render deterministically. The fixture is the same for every segment
+// id, so tests must assert on structure/visibility, not data values.
+export const mockHydrovizApi = async (page: Page) => {
+  await page.route('**/*_hydrology/hydroviz/**', route => {
+    const fixture = route.request().url().includes('arctic_hydrology')
+      ? 'alaska_output_example.json'
+      : 'conus_output_example.json'
+    route.fulfill({
+      contentType: 'application/json',
+      body: fs.readFileSync(fixturePath(fixture), 'utf-8'),
+    })
+  })
+}
+
+// Fail hydroviz data API requests so the store's apiFailed branch runs.
+export const mockHydrovizApiFailure = async (page: Page) => {
+  await page.route('**/*_hydrology/hydroviz/**', route => {
+    route.fulfill({ status: 500, body: 'Internal Server Error' })
+  })
+}
+
+// Answer GeoServer WFS queries with an empty FeatureCollection (or a
+// test-supplied response) and all map tile requests with a transparent PNG,
+// so Leaflet maps and search autocomplete settle without the network.
+export const mockMapServices = async (
+  page: Page,
+  wfsResponder?: (url: string) => object | undefined
+) => {
+  await page.route('**/geoserver/**', route => {
+    const url = route.request().url()
+    if (url.includes('GetFeature')) {
+      const custom = wfsResponder?.(url)
+      return route.fulfill({
+        contentType: 'application/json',
+        body: custom ? JSON.stringify(custom) : emptyFeatureCollection,
+      })
+    }
+    return route.fulfill({ contentType: 'image/png', body: transparentPng })
+  })
+  await page.route('**/basemap.nationalmap.gov/**', route =>
+    route.fulfill({ contentType: 'image/png', body: transparentPng })
+  )
+}

--- a/webapp/tests/e2e/helpers.ts
+++ b/webapp/tests/e2e/helpers.ts
@@ -8,6 +8,17 @@ import type { Page } from '@playwright/test'
 // in assets/fixtures/; the failure test fulfills with a 500 instead. This
 // keeps every test deterministic and offline while still exercising the real
 // fetch/loading/error code paths in stores/streamSegment.ts.
+//
+// Live mode (HYDROVIZ_E2E_LIVE=true, or implied by HYDROVIZ_E2E_BASE_URL)
+// turns these helpers into no-ops so the same tests run against the real
+// Data API, GeoServer, and basemap services — for checking that a deployed
+// site and its external dependencies actually work together. The API-failure
+// mock still intercepts in live mode, since it tests how the app responds to
+// a forced outage, not whether the service is up.
+
+export const liveMode =
+  process.env.HYDROVIZ_E2E_LIVE === 'true' ||
+  !!process.env.HYDROVIZ_E2E_BASE_URL
 
 const fixturePath = (name: string) =>
   path.join(process.cwd(), 'assets', 'fixtures', name)
@@ -27,6 +38,7 @@ const transparentPng = Buffer.from(
 // pages render deterministically. The fixture is the same for every segment
 // id, so tests must assert on structure/visibility, not data values.
 export const mockHydrovizApi = async (page: Page) => {
+  if (liveMode) return
   await page.route('**/*_hydrology/hydroviz/**', route => {
     const fixture = route.request().url().includes('arctic_hydrology')
       ? 'alaska_output_example.json'
@@ -52,6 +64,7 @@ export const mockMapServices = async (
   page: Page,
   wfsResponder?: (url: string) => object | undefined
 ) => {
+  if (liveMode) return
   await page.route('**/geoserver/**', route => {
     const url = route.request().url()
     if (url.includes('GetFeature')) {

--- a/webapp/tests/e2e/smoke.spec.ts
+++ b/webapp/tests/e2e/smoke.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test'
 import {
+  liveMode,
   mockHydrovizApi,
   mockHydrovizApiFailure,
   mockMapServices,
@@ -71,9 +72,24 @@ test('data API failure shows the failure message', async ({ page }) => {
 })
 
 test('searching a gage id navigates to its report', async ({ page }) => {
+  // In live mode the autocomplete queries real GeoServer, so search for a
+  // real USGS gage (on segment 52448, a known gaged stream per AGENTS.md).
+  // In mock mode the gage-id WFS query is served one fake CONUS result and
+  // the other three autocomplete queries (HUCs, Alaska gages) fall through
+  // to empty.
+  const search = liveMode
+    ? {
+        query: '12161000',
+        result: 'South Fork Stillaguamish River (USGS-12161000)',
+        reportUrl: /\/conus\/stream\/52448/,
+      }
+    : {
+        query: '01234567',
+        result: 'Test Creek (01234567)',
+        reportUrl: /\/conus\/stream\/32174/,
+      }
+
   await mockMapServices(page, url => {
-    // The gage-id WFS query gets one fake CONUS result; the other three
-    // autocomplete queries (HUCs, Alaska gages) fall through to empty.
     if (url.includes('seg_h8_outlet_stats_simplified_v2')) {
       return {
         type: 'FeatureCollection',
@@ -93,10 +109,10 @@ test('searching a gage id navigates to its report', async ({ page }) => {
   await mockHydrovizApi(page)
 
   await page.goto('/')
-  await page.locator('#search').pressSequentially('01234567')
-  await page.getByText('Test Creek (01234567)').click()
+  await page.locator('#search').pressSequentially(search.query)
+  await page.getByText(search.result).click()
 
-  await expect(page).toHaveURL(/\/conus\/stream\/32174/)
+  await expect(page).toHaveURL(search.reportUrl)
   await expect(
     page.getByRole('heading', { name: /Statistics for/ })
   ).toBeVisible()

--- a/webapp/tests/e2e/smoke.spec.ts
+++ b/webapp/tests/e2e/smoke.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test'
+import {
+  mockHydrovizApi,
+  mockHydrovizApiFailure,
+  mockMapServices,
+} from './helpers'
+
+// A small smoke suite covering the highest-value user flows. All external
+// services are mocked (see helpers.ts), and the report fixtures return the
+// same example data for every segment id — so these tests assert on page
+// structure and visibility, never on specific data values.
+
+test('home page renders both region maps', async ({ page }) => {
+  const pageErrors: Error[] = []
+  page.on('pageerror', error => pageErrors.push(error))
+  await mockMapServices(page)
+
+  await page.goto('/')
+
+  await expect(
+    page.getByRole('heading', { name: 'Hydrologic Outlooks' })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('heading', { name: 'Continental United States' })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('heading', { name: 'Alaska', exact: true })
+  ).toBeVisible()
+
+  expect(pageErrors).toEqual([])
+})
+
+test('CONUS report renders stats and charts', async ({ page }) => {
+  await mockMapServices(page)
+  await mockHydrovizApi(page)
+
+  await page.goto('/conus/stream/32174')
+
+  await expect(
+    page.getByRole('heading', { name: /Statistics for/ })
+  ).toBeVisible()
+  // Loading state has resolved.
+  await expect(page.locator('progress')).toHaveCount(0)
+  await expect(page.locator('table').first()).toBeVisible()
+  await expect(page.locator('.js-plotly-plot').first()).toBeVisible()
+})
+
+test('Alaska report renders stats and charts', async ({ page }) => {
+  await mockMapServices(page)
+  await mockHydrovizApi(page)
+
+  await page.goto('/alaska/stream/81015240')
+
+  await expect(
+    page.getByRole('heading', { name: /Statistics for/ })
+  ).toBeVisible()
+  await expect(page.locator('progress')).toHaveCount(0)
+  await expect(page.locator('table').first()).toBeVisible()
+  await expect(page.locator('.js-plotly-plot').first()).toBeVisible()
+})
+
+test('data API failure shows the failure message', async ({ page }) => {
+  await mockMapServices(page)
+  await mockHydrovizApiFailure(page)
+
+  await page.goto('/conus/stream/32174')
+
+  await expect(
+    page.getByText(/experiencing technical difficulties/)
+  ).toBeVisible()
+})
+
+test('searching a gage id navigates to its report', async ({ page }) => {
+  await mockMapServices(page, url => {
+    // The gage-id WFS query gets one fake CONUS result; the other three
+    // autocomplete queries (HUCs, Alaska gages) fall through to empty.
+    if (url.includes('seg_h8_outlet_stats_simplified_v2')) {
+      return {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            properties: {
+              seg_id_nat: 32174,
+              GNIS_NAME: 'Test Creek',
+              GAGE_ID: '01234567',
+            },
+          },
+        ],
+      }
+    }
+  })
+  await mockHydrovizApi(page)
+
+  await page.goto('/')
+  await page.locator('#search').pressSequentially('01234567')
+  await page.getByText('Test Creek (01234567)').click()
+
+  await expect(page).toHaveURL(/\/conus\/stream\/32174/)
+  await expect(
+    page.getByRole('heading', { name: /Statistics for/ })
+  ).toBeVisible()
+})
+
+test('static content page loads via direct URL', async ({ page }) => {
+  await page.goto('/data-and-methodology')
+
+  await expect(
+    page.getByRole('heading', { name: 'Data, Methodology & Bibliography' })
+  ).toBeVisible()
+})


### PR DESCRIPTION
Adds a small Playwright suite covering the highest-value user flows, deliberately scoped to a handful of high-quality tests rather than exhaustive coverage.

**Six tests**, run against Chromium and Firefox (12 total):

- Home page renders both region maps, with no uncaught page errors
- CONUS report (`/conus/stream/32174`) renders title, stats table, and charts
- Alaska report (`/alaska/stream/81015240`) — same, exercising the region split
- Data API failure surfaces the failure message rather than hanging
- Search by gage ID navigates to the corresponding report
- `/data-and-methodology` loads via direct URL, guarding the static-SPA routing path

**Mocking approach:** all external services (hydroviz data API, GeoServer, basemap tiles) are intercepted with `page.route`, so the suite is deterministic and runs offline. Report tests are served the same `assets/fixtures/` JSON the app bundles — note this fixture is identical for every segment ID, so tests assert on page structure and visibility, never on data values.

Rather than running the dev server with `HYDROVIZ_USE_STATIC_FIXTURES=true`, the server runs without it so requests actually hit the network where the mocks intercept them. This keeps the real fetch/timeout/error paths in `stores/streamSegment.ts` under test — the API-failure case is unreachable in fixtures mode.

Run with `npm run test:e2e`; see the new Testing section in `webapp/README.md` for setup.

Note for reviewers: this branch was AI-generated with Claude Code and should be reviewed accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)