### PR TITLE
Add scenario to title of Alaskan & CONUS charts where it was missing

### DIFF
--- a/webapp/components/Viz/Hydrograph.vue
+++ b/webapp/components/Viz/Hydrograph.vue
@@ -396,8 +396,6 @@ const buildChart = hg => {
     x: 0.5,
   }
 
-  let isTwoLineTitle = gageId.value ? true : false
-
   let layout = getLayout(
     'hydrograph',
     titleText,
@@ -405,7 +403,6 @@ const buildChart = hg => {
     xAxisConfig,
     yAxisConfig,
     legendConfig,
-    isTwoLineTitle,
     isAlaskaData
   )
 
@@ -432,7 +429,6 @@ const buildChart = hg => {
         xAxisConfig,
         yAxisConfig,
         legendConfig,
-        isTwoLineTitle,
         isAlaskaData
       )
       let pngName2 = `hydrograph_${segmentId.value}_rcp85_${appEra.value}`

--- a/webapp/components/Viz/MaxFlowDates.vue
+++ b/webapp/components/Viz/MaxFlowDates.vue
@@ -67,7 +67,7 @@ const buildChart = () => {
   let titleText: string
   let gageIdLine = getGageIdLine(gageId.value)
   if (isAlaskaData) {
-    titleText = `Modeled flow rate at date of annual maximum daily flow, 2034-2065${gageIdLine}`
+    titleText = `Modeled flow rate at date of annual maximum daily flow, 2034-2065<br>${scenarioFullNames['ssp370']}${gageIdLine}`
 
     let historicalFlow = [props.streamMaxFlowDates['historical']['flow']]
     let historicalFlowDate = [props.streamMaxFlowDates['historical']['date']]
@@ -218,7 +218,6 @@ const buildChart = () => {
     traceorder: 'reversed',
   }
 
-  let isTwoLineTitle = gageId.value ? true : false
   let layout = getLayout(
     'maxFlowDates',
     titleText,
@@ -226,7 +225,6 @@ const buildChart = () => {
     {},
     {},
     legendConfig,
-    isTwoLineTitle,
     isAlaskaData
   )
 

--- a/webapp/components/Viz/MaxFlowDates.vue
+++ b/webapp/components/Viz/MaxFlowDates.vue
@@ -64,10 +64,22 @@ const buildChart = () => {
     rcp85: 'cross',
   }
 
-  let titleText: string
+  let titleText = ''
+  let scenarioSubtitle = ''
   let gageIdLine = getGageIdLine(gageId.value)
   if (isAlaskaData) {
-    titleText = `Modeled flow rate at date of annual maximum daily flow, 2034-2065<br>${scenarioFullNames['ssp370']}${gageIdLine}`
+    scenarioSubtitle = scenarioFullNames['ssp370']
+  } else {
+    if (appContext.value === 'mid') {
+      scenarioSubtitle = scenarioFullNames['rcp60']
+    } else {
+      scenarioSubtitle =
+        scenarioFullNames['rcp45'] + ' &amp; ' + scenarioFullNames['rcp85']
+    }
+  }
+
+  if (isAlaskaData) {
+    titleText = `Modeled flow rate at date of annual maximum daily flow, 2034-2065<br>${scenarioSubtitle}${gageIdLine}`
 
     let historicalFlow = [props.streamMaxFlowDates['historical']['flow']]
     let historicalFlowDate = [props.streamMaxFlowDates['historical']['date']]
@@ -126,7 +138,7 @@ const buildChart = () => {
 
     projectedTraces.push(trace)
   } else {
-    titleText = `Modeled flow rate at date of annual maximum daily flow, ${appEra.value}${gageIdLine}`
+    titleText = `Modeled flow rate at date of annual maximum daily flow, ${appEra.value}<br>${scenarioSubtitle}${gageIdLine}`
     scenarios.forEach(scenario => {
       let historicalFlow = [props.streamMaxFlowDates['historical']['flow']]
       let historicalFlowDate = [props.streamMaxFlowDates['historical']['date']]

--- a/webapp/components/Viz/MaxTemperatureDates.vue
+++ b/webapp/components/Viz/MaxTemperatureDates.vue
@@ -52,7 +52,7 @@ const buildChart = () => {
   }
 
   let gageIdLine = getGageIdLine(gageId.value)
-  let titleText = `Modeled water temperature at date of annual maximum, 2034-2065${gageIdLine}`
+  let titleText = `Modeled water temperature at date of annual maximum, 2034-2065<br>${scenarioFullNames['ssp370']}${gageIdLine}`
 
   let historicalTemp = [props.streamMaxTempDates['historical']['temperature']]
   let historicalTempDate = [props.streamMaxTempDates['historical']['date']]
@@ -125,7 +125,6 @@ const buildChart = () => {
     traceorder: 'reversed',
   }
 
-  let isTwoLineTitle = gageId.value ? true : false
   const isAlaskaData = true
 
   const layout = getLayout(
@@ -135,7 +134,6 @@ const buildChart = () => {
     {},
     {},
     legendConfig,
-    isTwoLineTitle,
     isAlaskaData
   )
 

--- a/webapp/components/Viz/MonthlyFlow.vue
+++ b/webapp/components/Viz/MonthlyFlow.vue
@@ -175,10 +175,21 @@ const buildChart = () => {
     })
   }
 
+  let titleText = ''
+  let scenarioSubtitle = ''
   let gageIdLine = getGageIdLine(gageId.value)
-  const titleText: string = isAlaskaData
-    ? `Mean monthly modeled flow rate, 2034-2065<br>${scenarioFullNames['ssp370']}${gageIdLine}`
-    : `Mean monthly modeled flow rate, ${appEra.value}${gageIdLine}`
+  if (isAlaskaData) {
+    scenarioSubtitle = scenarioFullNames['ssp370']
+    titleText = `Mean monthly modeled flow rate, 2034-2065<br>${scenarioSubtitle}${gageIdLine}`
+  } else {
+    if (appContext.value === 'mid') {
+      scenarioSubtitle = scenarioFullNames['rcp60']
+    } else {
+      scenarioSubtitle =
+        scenarioFullNames['rcp45'] + ' &amp; ' + scenarioFullNames['rcp85']
+    }
+    titleText = `Mean monthly modeled flow rate, ${appEra.value}<br>${scenarioSubtitle}${gageIdLine}`
+  }
 
   let xAxisSettings = {
     tickvals: $_.range(Object.values(monthLabels).length),

--- a/webapp/components/Viz/MonthlyFlow.vue
+++ b/webapp/components/Viz/MonthlyFlow.vue
@@ -177,7 +177,7 @@ const buildChart = () => {
 
   let gageIdLine = getGageIdLine(gageId.value)
   const titleText: string = isAlaskaData
-    ? `Mean monthly modeled flow rate, 2034-2065${gageIdLine}`
+    ? `Mean monthly modeled flow rate, 2034-2065<br>${scenarioFullNames['ssp370']}${gageIdLine}`
     : `Mean monthly modeled flow rate, ${appEra.value}${gageIdLine}`
 
   let xAxisSettings = {
@@ -201,8 +201,6 @@ const buildChart = () => {
     x: 0.5,
   }
 
-  let isTwoLineTitle = gageId.value ? true : false
-
   let layout = getLayout(
     'monthlyFlow',
     titleText,
@@ -210,7 +208,6 @@ const buildChart = () => {
     xAxisSettings,
     yAxisSettings,
     legendConfig,
-    isTwoLineTitle,
     isAlaskaData
   )
 

--- a/webapp/components/Viz/MonthlyTemperature.vue
+++ b/webapp/components/Viz/MonthlyTemperature.vue
@@ -126,7 +126,7 @@ const buildChart = () => {
   })
 
   let gageIdLine = getGageIdLine(gageId.value)
-  const titleText = `Mean monthly modeled water temperature, 2034-2065${gageIdLine}`
+  const titleText = `Mean monthly modeled water temperature, 2034-2065<br>${scenarioFullNames['ssp370']}${gageIdLine}`
 
   let xAxisSettings = {
     tickvals: $_.range(Object.values(monthLabels).length),
@@ -149,7 +149,6 @@ const buildChart = () => {
     x: 0.5,
   }
 
-  let isTwoLineTitle = gageId.value ? true : false
   const isAlaskaData = true
 
   let layout = getLayout(
@@ -159,7 +158,6 @@ const buildChart = () => {
     xAxisSettings,
     yAxisSettings,
     legendConfig,
-    isTwoLineTitle,
     isAlaskaData
   )
 

--- a/webapp/components/Viz/TemperatureHydrograph.vue
+++ b/webapp/components/Viz/TemperatureHydrograph.vue
@@ -209,7 +209,6 @@ const buildChart = hg => {
     x: 0.5,
   }
 
-  let isTwoLineTitle = gageId.value ? true : false
   const isAlaskaData = true
 
   let layout = getLayout(
@@ -219,7 +218,6 @@ const buildChart = hg => {
     xAxisConfig,
     yAxisConfig,
     legendConfig,
-    isTwoLineTitle,
     isAlaskaData
   )
 

--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -129,19 +129,21 @@ const getLayoutPositions = (
         3: { height: 600, marginTop: 150, marginBottom: 140, footerY: -0.37 },
       },
     },
-    // CONUS never has 3-line titles, so there are no 3-line layout configurations.
     conus: {
       hydrograph: {
         1: { height: 532, marginTop: 80, marginBottom: 177, footerY: -0.57 },
         2: { height: 552, marginTop: 100, marginBottom: 177, footerY: -0.57 },
+        3: { height: 572, marginTop: 120, marginBottom: 177, footerY: -0.57 },
       },
       monthlyBoxPlots: {
         1: { height: 525, marginTop: 80, marginBottom: 165, footerY: -0.5 },
-        2: { height: 540, marginTop: 100, marginBottom: 165, footerY: -0.5 },
+        2: { height: 545, marginTop: 100, marginBottom: 165, footerY: -0.5 },
+        3: { height: 585, marginTop: 140, marginBottom: 165, footerY: -0.5 },
       },
       maxDates: {
         1: { height: 555, marginTop: 100, marginBottom: 150, footerY: -0.42 },
         2: { height: 575, marginTop: 120, marginBottom: 150, footerY: -0.42 },
+        3: { height: 610, marginTop: 155, marginBottom: 150, footerY: -0.42 },
       },
     },
   }

--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -40,6 +40,12 @@ export const getGageIdLine = (gageId: string | null): string => {
     : ''
 }
 
+// Count the number of lines in a title by counting <br> tags.
+export const getTitleLineCount = (title: string): number => {
+  const brCount = (title.match(/<br>/gi) || []).length
+  return brCount + 1
+}
+
 const getFooterText = (isAlaskaData: boolean, chartType: string): string => {
   let projectedModels = isAlaskaData
     ? 'four climate model runs'
@@ -79,92 +85,77 @@ const getFooterText = (isAlaskaData: boolean, chartType: string): string => {
 // Keep plot area, footer position, and margins consistent across chart types.
 // For both web display and exported PNG images.
 const getLayoutPositions = (
-  isTwoLineTitle: boolean,
+  title: string,
   isAlaskaData: boolean,
   chartType: string
 ) => {
-  let height: null | number = null
-  let marginTop: null | number = null
-  let marginBottom: null | number = null
-  let footerY: null | number = null
   const generalizedChartType = generalizedChartTypes[chartType]
   if (!generalizedChartType) {
     throw new Error(`Unknown chartType "${chartType}"`)
   }
-  if (isTwoLineTitle) {
-    if (isAlaskaData) {
-      if (generalizedChartType === 'hydrograph') {
-        height = 542
-        marginTop = 100
-        marginBottom = 167
-        footerY = -0.52
-      } else if (generalizedChartType === 'monthlyBoxPlots') {
-        height = 545
-        marginTop = 120
-        marginBottom = 150
-        footerY = -0.45
-      } else if (generalizedChartType === 'maxDates') {
-        height = 570
-        marginTop = 120
-        marginBottom = 140
-        footerY = -0.37
-      }
-    } else {
-      if (generalizedChartType === 'hydrograph') {
-        height = 552
-        marginTop = 100
-        marginBottom = 177
-        footerY = -0.57
-      } else if (generalizedChartType === 'monthlyBoxPlots') {
-        height = 540
-        marginTop = 100
-        marginBottom = 165
-        footerY = -0.5
-      } else if (generalizedChartType === 'maxDates') {
-        height = 575
-        marginTop = 120
-        marginBottom = 150
-        footerY = -0.42
-      }
-    }
-  } else {
-    if (isAlaskaData) {
-      if (generalizedChartType === 'hydrograph') {
-        height = 522
-        marginTop = 80
-        marginBottom = 167
-        footerY = -0.52
-      } else if (generalizedChartType === 'monthlyBoxPlots') {
-        height = 525
-        marginTop = 100
-        marginBottom = 150
-        footerY = -0.45
-      } else if (generalizedChartType === 'maxDates') {
-        height = 550
-        marginTop = 100
-        marginBottom = 140
-        footerY = -0.37
-      }
-    } else {
-      if (generalizedChartType === 'hydrograph') {
-        height = 532
-        marginTop = 80
-        marginBottom = 177
-        footerY = -0.57
-      } else if (generalizedChartType === 'monthlyBoxPlots') {
-        height = 525
-        marginTop = 80
-        marginBottom = 165
-        footerY = -0.5
-      } else if (generalizedChartType === 'maxDates') {
-        height = 555
-        marginTop = 100
-        marginBottom = 150
-        footerY = -0.42
-      }
-    }
+
+  const titleLines = getTitleLineCount(title)
+
+  // Layout configuration lookup table: region -> chartType -> titleLines -> config
+  const layoutConfigs: Record<
+    string,
+    Record<
+      string,
+      Record<
+        number,
+        {
+          height: number
+          marginTop: number
+          marginBottom: number
+          footerY: number
+        }
+      >
+    >
+  > = {
+    alaska: {
+      hydrograph: {
+        1: { height: 522, marginTop: 80, marginBottom: 167, footerY: -0.52 },
+        2: { height: 542, marginTop: 100, marginBottom: 167, footerY: -0.52 },
+        3: { height: 562, marginTop: 120, marginBottom: 167, footerY: -0.52 },
+      },
+      monthlyBoxPlots: {
+        1: { height: 525, marginTop: 100, marginBottom: 150, footerY: -0.45 },
+        2: { height: 545, marginTop: 120, marginBottom: 150, footerY: -0.45 },
+        3: { height: 565, marginTop: 140, marginBottom: 150, footerY: -0.45 },
+      },
+      maxDates: {
+        1: { height: 550, marginTop: 100, marginBottom: 140, footerY: -0.37 },
+        2: { height: 565, marginTop: 115, marginBottom: 140, footerY: -0.37 },
+        3: { height: 600, marginTop: 150, marginBottom: 140, footerY: -0.37 },
+      },
+    },
+    // CONUS never has 3-line titles, so there are no 3-line layout configurations.
+    conus: {
+      hydrograph: {
+        1: { height: 532, marginTop: 80, marginBottom: 177, footerY: -0.57 },
+        2: { height: 552, marginTop: 100, marginBottom: 177, footerY: -0.57 },
+      },
+      monthlyBoxPlots: {
+        1: { height: 525, marginTop: 80, marginBottom: 165, footerY: -0.5 },
+        2: { height: 540, marginTop: 100, marginBottom: 165, footerY: -0.5 },
+      },
+      maxDates: {
+        1: { height: 555, marginTop: 100, marginBottom: 150, footerY: -0.42 },
+        2: { height: 575, marginTop: 120, marginBottom: 150, footerY: -0.42 },
+      },
+    },
   }
-  return { height, marginTop, marginBottom, footerY }
+
+  const region = isAlaskaData ? 'alaska' : 'conus'
+  const config = layoutConfigs[region]?.[generalizedChartType]?.[titleLines]
+
+  if (!config) {
+    throw new Error(
+      `No layout configuration found for region=${region}, chartType=${generalizedChartType}, titleLines=${titleLines}`
+    )
+  }
+
+  return config
 }
 
 export const getLayout = (
@@ -174,11 +165,10 @@ export const getLayout = (
   xAxisConfig?: Partial<Layout['xaxis']>,
   yAxisConfig?: Partial<Layout['yaxis']>,
   legendConfig?: Partial<Layout['legend']>,
-  isTwoLineTitle: boolean = false,
   isAlaskaData: boolean = false
 ): Partial<Layout> => {
   let { height, marginTop, marginBottom, footerY } = getLayoutPositions(
-    isTwoLineTitle,
+    title,
     isAlaskaData,
     chartType
   )

--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -180,7 +180,11 @@ export const getLayout = (
       font: {
         size: 24,
       },
-      automargin: true,
+      // automargin must stay off: margins are managed by getLayoutPositions,
+      // and Plotly's automargin push path clips multi-line container-ref
+      // titles when the configured margin is within a few px of the title
+      // height (browser-dependent, e.g. Firefox).
+      automargin: false,
       yref: 'container',
       y: 0.93,
     },

--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -42,7 +42,7 @@ export const getGageIdLine = (gageId: string | null): string => {
 
 // Count the number of lines in a title by counting <br> tags.
 export const getTitleLineCount = (title: string): number => {
-  const brCount = (title.match(/<br>/gi) || []).length
+  const brCount = (title.match(/<br\s*\/?>/gi) || []).length
   return brCount + 1
 }
 


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/280
Closes https://github.com/ua-snap/hydroviz/issues/232

This PR adds the scenario label(s) to the titles of:

- Monthly boxplot charts for Alaska (both flow & temperature)
- Circular max date charts for Alaska (both flow & temperature)
- Monthly mean flow boxplot charts for CONUS
- Circular max flow date chart for CONUS

To make this work, I also needed to update the `getLayoutPositions` function to recognize 3-line chart titles (when a Gage ID is also present) and adjust chart height, margins, and positioning as necessary. This code has been refactored a bit to make it simpler, and took care of issue #232 in the process.

To test, here are URLs for CONUS and Alaska stream segment reports both with and without Gage IDs:

- A CONUS stream segment with a corresponding USGS gage (e.g., http://localhost:3000/conus/stream/51206)
- An Alaska stream segment with a corresponding USGS gage (e.g., http://localhost:3000/alaska/stream/81033944)
- A CONUS stream segment without a corresponding USGS gage (e.g., http://localhost:3000/conus/stream/33812)
- An Alaska stream segment without a corresponding USGS gage (e.g., http://localhost:3000/alaska/stream/81029424)