### PR TITLE
Disable chart title automargin to fix clipped titles in Firefox

### DIFF
--- a/webapp/utils/chart.ts
+++ b/webapp/utils/chart.ts
@@ -180,7 +180,11 @@ export const getLayout = (
       font: {
         size: 24,
       },
-      automargin: true,
+      // automargin must stay off: margins are managed by getLayoutPositions,
+      // and Plotly's automargin push path clips multi-line container-ref
+      // titles when the configured margin is within a few px of the title
+      // height (browser-dependent, e.g. Firefox).
+      automargin: false,
       yref: 'container',
       y: 0.93,
     },


### PR DESCRIPTION
## Problem

On CONUS report pages (e.g. `/conus/stream/33812`), the first line of the Mean Monthly Flow chart title was clipped above the top of the SVG — but only in Firefox.

## Root cause

`getLayout` set `automargin: true` on the title alongside `yref: 'container'`, `y: 0.93`. On every draw, Plotly compares the measured title height + container offset against the configured top margin (`plotly.js/src/plot_api/subroutines.js`, `drawMainTitle`). For the 2-line CONUS box plot title:

- Firefox measures the title at **64.2px** → required margin ≈ **102.4** → exceeds `marginTop: 100` → triggers Plotly's automargin reposition path
- Chrome measures the same text at **60.2px** → required margin ≈ **98.4** → just under the threshold (by 1.65px!) → nothing happens

Plotly's reposition path is buggy for multi-line `yref: 'container'` titles: it rewrites the per-line `dy` values from `[0em, 1.3em]` to `[-1.65em, -0.35em]`, hoisting the first line above the SVG where it gets clipped. Forcing `margin.t: 95` reproduces the identical clipping in Chrome, confirming this is a threshold crossing (browser font-measurement variance) rather than a Firefox rendering bug.

Only the Mean Monthly Flow chart broke because its config is the only one within the ~4px Firefox/Chrome measurement window; the other charts' margins clear the threshold in both browsers.

## Fix

Disable `automargin` on the title. Margins are fully hand-managed via the `getLayoutPositions` lookup table, and the title position (`yref: 'container'`) doesn't depend on margins — so automargin's only possible effect here is triggering the broken reposition path. This removes the fragile threshold for every chart config rather than nudging one margin value past it.

## Testing

Playwright sweep (Firefox + Chromium) asserting every chart title renders below the SVG top, inside its top margin, with non-negative line offsets:

- CONUS `/conus/stream/33812`: mid + extremes contexts, eras 2016-2045 / 2046-2075 / 2071-2100
- Alaska `/alaska/stream/81015240`

41 title checks, 0 failures, no visual layout shift in either browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)