### PR TITLE
Change outflows "are shown in red" to outflows "are shown in orange"

### DIFF
--- a/webapp/components/Report/Map.vue
+++ b/webapp/components/Report/Map.vue
@@ -106,7 +106,7 @@ onMounted(() => {
       :style="{ backgroundColor: outletRed }"
       aria-hidden="true"
     ></span>
-    Watershed outflow segments in the map below are shown in red.
+    Watershed outflow segments in the map below are shown in orange.
   </p>
   <div class="report-map-wrapper mb-6">
     <div id="report-map"></div>

--- a/webapp/pages/how-to.vue
+++ b/webapp/pages/how-to.vue
@@ -184,7 +184,7 @@
             <li>
               He zooms in on the map and selects the
               <NuxtLink to="/conus/stream/559">Sheepscot River</NuxtLink
-              >&mdash;the outflow segment for a watershed, shown in red.
+              >&mdash;the outflow segment for a watershed, shown in orange.
             </li>
             <li>
               In the results summary, he notes that some model outputs vary by


### PR DESCRIPTION
Closes https://github.com/ua-snap/hydroviz/issues/279.

This PR simply changes this text:

> Watershed outflow segments in the map below are shown in red.

To:

> Watershed outflow segments in the map below are shown in orange.

Since the color appears more orange to most of us (and Claude agrees).